### PR TITLE
Add a newline after output

### DIFF
--- a/src/Changelogs.php
+++ b/src/Changelogs.php
@@ -57,7 +57,7 @@ class Changelogs
             $this->createUpdateOutput($output, $update);
         }
 
-        return implode("\n", $output);
+        return implode("\n", $output)."\n";
     }
 
     private function createUpdateOutput(array &$output, Update $update)


### PR DESCRIPTION
This should be done for better readability if another plugins / scripts displays information.

Good:

```
  - Removing symfony/framework-bundle (v2.7.4)
  - Installing symfony/framework-bundle (v2.3.33)
    Loading from cache

Writing lock file
[...]
```

Bad:

```
 - symfony/framework-bundle updated from v2.7.4 to v2.3.33
   See changes: https://github.com/symfony/framework-bundle/compare/v2.7.4...v2.3.33
   Release notes: https://github.com/symfony/framework-bundle/releases/tag/v2.3.33
gregwar/image: 1.0.1 -> v2.0.20
Processing...
```
