### PR TITLE
Add support for dev versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * Add support for bitbucket repositories
  * Add new line after plugin output
  * Add support for install and uninstall operations
+ * Add support for dev versions
  
  ## 1.0 (2015-09-26)
  

--- a/src/OperationHandler/InstallHandler.php
+++ b/src/OperationHandler/InstallHandler.php
@@ -14,6 +14,7 @@ namespace Pyrech\ComposerChangelogs\OperationHandler;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Pyrech\ComposerChangelogs\UrlGenerator\UrlGenerator;
+use Pyrech\ComposerChangelogs\Version;
 
 class InstallHandler implements OperationHandler
 {
@@ -49,12 +50,16 @@ class InstallHandler implements OperationHandler
         $output = [];
 
         $package = $operation->getPackage();
-        $version = $package->getPrettyVersion();
+        $version = new Version(
+            $package->getVersion(),
+            $package->getPrettyVersion(),
+            $package->getFullPrettyVersion()
+        );
 
         $output[] = sprintf(
             ' - <fg=green>%s</fg=green> installed in version <fg=yellow>%s</fg=yellow>',
             $package->getName(),
-            $version
+            $version->getPretty()
         );
 
         if ($urlGenerator) {

--- a/src/OperationHandler/UninstallHandler.php
+++ b/src/OperationHandler/UninstallHandler.php
@@ -14,6 +14,7 @@ namespace Pyrech\ComposerChangelogs\OperationHandler;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Pyrech\ComposerChangelogs\UrlGenerator\UrlGenerator;
+use Pyrech\ComposerChangelogs\Version;
 
 class UninstallHandler implements OperationHandler
 {
@@ -49,12 +50,16 @@ class UninstallHandler implements OperationHandler
         $output = [];
 
         $package = $operation->getPackage();
-        $version = $package->getPrettyVersion();
+        $version = new Version(
+            $package->getVersion(),
+            $package->getPrettyVersion(),
+            $package->getFullPrettyVersion()
+        );
 
         $output[] = sprintf(
             ' - <fg=green>%s</fg=green> removed (installed version was <fg=yellow>%s</fg=yellow>)',
             $package->getName(),
-            $version
+            $version->getPretty()
         );
 
         return $output;

--- a/src/OperationHandler/UpdateHandler.php
+++ b/src/OperationHandler/UpdateHandler.php
@@ -14,6 +14,7 @@ namespace Pyrech\ComposerChangelogs\OperationHandler;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Pyrech\ComposerChangelogs\UrlGenerator\UrlGenerator;
+use Pyrech\ComposerChangelogs\Version;
 
 class UpdateHandler implements OperationHandler
 {
@@ -51,14 +52,22 @@ class UpdateHandler implements OperationHandler
         $initialPackage = $operation->getInitialPackage();
         $targetPackage = $operation->getTargetPackage();
 
-        $versionFrom = $initialPackage->getPrettyVersion();
-        $versionTo = $targetPackage->getPrettyVersion();
+        $versionFrom = new Version(
+            $initialPackage->getVersion(),
+            $initialPackage->getPrettyVersion(),
+            $initialPackage->getFullPrettyVersion()
+        );
+        $versionTo = new Version(
+            $targetPackage->getVersion(),
+            $targetPackage->getPrettyVersion(),
+            $targetPackage->getFullPrettyVersion()
+        );
 
         $output[] = sprintf(
             ' - <fg=green>%s</fg=green> updated from <fg=yellow>%s</fg=yellow> to <fg=yellow>%s</fg=yellow>',
             $initialPackage->getName(),
-            $versionFrom,
-            $versionTo
+            $versionFrom->getPretty(),
+            $versionTo->getPretty()
         );
 
         if ($urlGenerator) {

--- a/src/UrlGenerator/AbstractUrlGenerator.php
+++ b/src/UrlGenerator/AbstractUrlGenerator.php
@@ -11,6 +11,8 @@
 
 namespace Pyrech\ComposerChangelogs\UrlGenerator;
 
+use Pyrech\ComposerChangelogs\Version;
+
 abstract class AbstractUrlGenerator implements UrlGenerator
 {
     /**
@@ -31,5 +33,38 @@ abstract class AbstractUrlGenerator implements UrlGenerator
             $sourceUrl['host'],
             $pos === false ? $sourceUrl['path'] : substr($sourceUrl['path'], 0, strrpos($sourceUrl['path'], '.git'))
         );
+    }
+
+    /**
+     * Return whether the version is dev or not.
+     *
+     * @param Version $version
+     *
+     * @return string
+     */
+    protected function isDevVersion(Version $version)
+    {
+        return substr($version->getName(), -4) === '-dev';
+    }
+
+    /**
+     * Get the version to use for the compare url.
+     *
+     * For dev versions, it returns the commit short hash in full pretty version.
+     *
+     * @param Version $version
+     *
+     * @return string
+     */
+    protected function getCompareVersion(Version $version)
+    {
+        if ($this->isDevVersion($version)) {
+            return substr(
+                $version->getFullPretty(),
+                strlen($version->getPretty()) + 1
+            );
+        }
+
+        return $version->getPretty();
     }
 }

--- a/src/UrlGenerator/BitbucketUrlGenerator.php
+++ b/src/UrlGenerator/BitbucketUrlGenerator.php
@@ -11,6 +11,8 @@
 
 namespace Pyrech\ComposerChangelogs\UrlGenerator;
 
+use Pyrech\ComposerChangelogs\Version;
+
 class BitbucketUrlGenerator extends AbstractUrlGenerator
 {
     const DOMAIN = 'bitbucket.org';
@@ -26,20 +28,20 @@ class BitbucketUrlGenerator extends AbstractUrlGenerator
     /**
      * {@inheritdoc}
      */
-    public function generateCompareUrl($sourceUrl, $versionFrom, $versionTo)
+    public function generateCompareUrl($sourceUrl, Version $versionFrom, Version $versionTo)
     {
         return sprintf(
             '%s/branches/compare/%s%%0D%s',
             $this->generateBaseUrl($sourceUrl),
-            $versionTo,
-            $versionFrom
+            $this->getCompareVersion($versionTo),
+            $this->getCompareVersion($versionFrom)
         );
     }
 
     /**
      * {@inheritdoc}
      */
-    public function generateReleaseUrl($sourceUrl, $version)
+    public function generateReleaseUrl($sourceUrl, Version $version)
     {
         // Releases are not supported on Bitbucket :'(
         return false;

--- a/src/UrlGenerator/GithubUrlGenerator.php
+++ b/src/UrlGenerator/GithubUrlGenerator.php
@@ -11,6 +11,8 @@
 
 namespace Pyrech\ComposerChangelogs\UrlGenerator;
 
+use Pyrech\ComposerChangelogs\Version;
+
 class GithubUrlGenerator extends AbstractUrlGenerator
 {
     const DOMAIN = 'github.com';
@@ -26,25 +28,29 @@ class GithubUrlGenerator extends AbstractUrlGenerator
     /**
      * {@inheritdoc}
      */
-    public function generateCompareUrl($sourceUrl, $versionFrom, $versionTo)
+    public function generateCompareUrl($sourceUrl, Version $versionFrom, Version $versionTo)
     {
         return sprintf(
             '%s/compare/%s...%s',
             $this->generateBaseUrl($sourceUrl),
-            $versionFrom,
-            $versionTo
+            $this->getCompareVersion($versionFrom),
+            $this->getCompareVersion($versionTo)
         );
     }
 
     /**
      * {@inheritdoc}
      */
-    public function generateReleaseUrl($sourceUrl, $version)
+    public function generateReleaseUrl($sourceUrl, Version $version)
     {
+        if ($this->isDevVersion($version)) {
+            return false;
+        }
+
         return sprintf(
             '%s/releases/tag/%s',
             $this->generateBaseUrl($sourceUrl),
-            $version
+            $version->getPretty()
         );
     }
 }

--- a/src/UrlGenerator/UrlGenerator.php
+++ b/src/UrlGenerator/UrlGenerator.php
@@ -11,6 +11,8 @@
 
 namespace Pyrech\ComposerChangelogs\UrlGenerator;
 
+use Pyrech\ComposerChangelogs\Version;
+
 interface UrlGenerator
 {
     /**
@@ -24,22 +26,22 @@ interface UrlGenerator
      * Return the compare url for these versions or false if compare url is not
      * supported.
      *
-     * @param string $sourceUrl
-     * @param string $versionFrom
-     * @param string $versionTo
+     * @param string  $sourceUrl
+     * @param Version $versionFrom
+     * @param Version $versionTo
      *
      * @return string|false
      */
-    public function generateCompareUrl($sourceUrl, $versionFrom, $versionTo);
+    public function generateCompareUrl($sourceUrl, Version $versionFrom, Version $versionTo);
 
     /**
      * Return the release url for the given version or false if compare url is
      * not supported.
      *
-     * @param string $sourceUrl
-     * @param string $version
+     * @param string  $sourceUrl
+     * @param Version $version
      *
      * @return string|false
      */
-    public function generateReleaseUrl($sourceUrl, $version);
+    public function generateReleaseUrl($sourceUrl, Version $version);
 }

--- a/src/Version.php
+++ b/src/Version.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the composer-changelogs project.
+ *
+ * (c) Loïck Piera <pyrech@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pyrech\ComposerChangelogs;
+
+class Version
+{
+    /** @var string */
+    private $name;
+
+    /** @var string */
+    private $pretty;
+
+    /** @var string */
+    private $fullPretty;
+
+    /**
+     * @param string $name
+     * @param string $pretty
+     * @param string $fullPretty
+     */
+    public function __construct($name, $pretty, $fullPretty)
+    {
+        $this->name = $name;
+        $this->pretty = $pretty;
+        $this->fullPretty = $fullPretty;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPretty()
+    {
+        return $this->pretty;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFullPretty()
+    {
+        return $this->fullPretty;
+    }
+}

--- a/tests/UrlGenerator/BitbucketUrlGeneratorTest.php
+++ b/tests/UrlGenerator/BitbucketUrlGeneratorTest.php
@@ -12,6 +12,7 @@
 namespace Pyrech\ComposerChangelogs\tests\UrlGenerator;
 
 use Pyrech\ComposerChangelogs\UrlGenerator\BitbucketUrlGenerator;
+use Pyrech\ComposerChangelogs\Version;
 
 class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,37 +36,71 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->SUT->supports('https://github.com/symfony/console'));
     }
 
-    public function test_it_generate_compare_urls()
+    public function test_it_generates_compare_urls_with_or_without_git_extension_in_source_url()
     {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
         $this->assertSame(
             'https://bitbucket.org/acme/repo/branches/compare/v1.0.1%0Dv1.0.0',
             $this->SUT->generateCompareUrl(
                 'https://bitbucket.org/acme/repo',
-                'v1.0.0',
-                'v1.0.1'
+                $versionFrom,
+                $versionTo
             )
         );
 
         $this->assertSame(
-            'https://bitbucket.org/acme/repo/branches/compare/v1.0.2%0Dv1.0.1',
+            'https://bitbucket.org/acme/repo/branches/compare/v1.0.1%0Dv1.0.0',
             $this->SUT->generateCompareUrl(
                 'https://bitbucket.org/acme/repo.git',
-                'v1.0.1',
-                'v1.0.2'
+                $versionFrom,
+                $versionTo
+            )
+        );
+    }
+
+    public function test_it_generates_compare_urls_with_dev_versions()
+    {
+        $versionFrom = new Version('v1.0.9999999.9999999-dev', 'dev-master', 'dev-master 1234abc');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertSame(
+            'https://bitbucket.org/acme/repo/branches/compare/v1.0.1%0D1234abc',
+            $this->SUT->generateCompareUrl(
+                'https://bitbucket.org/acme/repo.git',
+                $versionFrom,
+                $versionTo
+            )
+        );
+
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('9999999-dev', 'dev-master', 'dev-master 6789def');
+
+        $this->assertSame(
+            'https://bitbucket.org/acme/repo/branches/compare/6789def%0Dv1.0.0',
+            $this->SUT->generateCompareUrl(
+                'https://bitbucket.org/acme/repo.git',
+                $versionFrom,
+                $versionTo
             )
         );
     }
 
     public function test_it_does_not_generate_release_urls()
     {
-        $this->assertFalse($this->SUT->generateReleaseUrl(
-            'https://bitbucket.org/acme/repo',
-            'v1.0.1'
-        ));
+        $this->assertFalse(
+            $this->SUT->generateReleaseUrl(
+                'https://bitbucket.org/acme/repo',
+                new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1')
+            )
+        );
 
-        $this->assertFalse($this->SUT->generateReleaseUrl(
-            'https://bitbucket.org/acme/repo.git',
-            'v1.0.2'
-        ));
+        $this->assertFalse(
+            $this->SUT->generateReleaseUrl(
+                'https://bitbucket.org/acme/repo.git',
+                new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1')
+            )
+        );
     }
 }

--- a/tests/UrlGenerator/GithubUrlGeneratorTest.php
+++ b/tests/UrlGenerator/GithubUrlGeneratorTest.php
@@ -12,6 +12,7 @@
 namespace Pyrech\ComposerChangelogs\tests\UrlGenerator;
 
 use Pyrech\ComposerChangelogs\UrlGenerator\GithubUrlGenerator;
+use Pyrech\ComposerChangelogs\Version;
 
 class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,42 +36,82 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->SUT->supports('https://bitbucket.org/rogoOOS/rog'));
     }
 
-    public function test_it_generate_compare_urls()
+    public function test_it_generates_compare_urls_with_or_without_git_extension_in_source_url()
     {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
         $this->assertSame(
             'https://github.com/acme/repo/compare/v1.0.0...v1.0.1',
             $this->SUT->generateCompareUrl(
                 'https://github.com/acme/repo',
-                'v1.0.0',
-                'v1.0.1'
+                $versionFrom,
+                $versionTo
             )
         );
 
         $this->assertSame(
-            'https://github.com/acme/repo/compare/v1.0.1...v1.0.2',
+            'https://github.com/acme/repo/compare/v1.0.0...v1.0.1',
             $this->SUT->generateCompareUrl(
                 'https://github.com/acme/repo.git',
-                'v1.0.1',
-                'v1.0.2'
+                $versionFrom,
+                $versionTo
             )
         );
     }
 
-    public function test_it_generate_release_urls()
+    public function test_it_generates_compare_urls_with_dev_versions()
+    {
+        $versionFrom = new Version('v.1.0.9999999.9999999-dev', 'dev-master', 'dev-master 1234abc');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertSame(
+            'https://github.com/acme/repo/compare/1234abc...v1.0.1',
+            $this->SUT->generateCompareUrl(
+                'https://github.com/acme/repo.git',
+                $versionFrom,
+                $versionTo
+            )
+        );
+
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('9999999-dev', 'dev-master', 'dev-master 6789def');
+
+        $this->assertSame(
+            'https://github.com/acme/repo/compare/v1.0.0...6789def',
+            $this->SUT->generateCompareUrl(
+                'https://github.com/acme/repo.git',
+                $versionFrom,
+                $versionTo
+            )
+        );
+    }
+
+    public function test_it_does_not_generate_release_urls_for_dev_version()
+    {
+        $this->assertFalse(
+            $this->SUT->generateReleaseUrl(
+                'https://github.com/acme/repo',
+                new Version('9999999-dev', 'dev-master', 'dev-master 1234abc')
+            )
+        );
+    }
+
+    public function test_it_generates_release_urls()
     {
         $this->assertSame(
             'https://github.com/acme/repo/releases/tag/v1.0.1',
             $this->SUT->generateReleaseUrl(
                 'https://github.com/acme/repo',
-                'v1.0.1'
+                new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1')
             )
         );
 
         $this->assertSame(
-            'https://github.com/acme/repo/releases/tag/v1.0.2',
+            'https://github.com/acme/repo/releases/tag/v1.0.1',
             $this->SUT->generateReleaseUrl(
                 'https://github.com/acme/repo.git',
-                'v1.0.2'
+                new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1')
             )
         );
     }

--- a/tests/resources/FakeHandler.php
+++ b/tests/resources/FakeHandler.php
@@ -14,6 +14,7 @@ namespace Pyrech\ComposerChangelogs\tests\resources;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Pyrech\ComposerChangelogs\OperationHandler\OperationHandler;
 use Pyrech\ComposerChangelogs\UrlGenerator\UrlGenerator;
+use Pyrech\ComposerChangelogs\Version;
 
 class FakeHandler implements OperationHandler
 {
@@ -68,8 +69,8 @@ class FakeHandler implements OperationHandler
         ];
 
         if ($urlGenerator) {
-            $output[] = '   '.$urlGenerator->generateCompareUrl($this->sourceUrl, '1', '2');
-            $output[] = '   '.$urlGenerator->generateReleaseUrl($this->sourceUrl, '2');
+            $output[] = '   '.$urlGenerator->generateCompareUrl($this->sourceUrl, new Version('', '', ''), new Version('', '', ''));
+            $output[] = '   '.$urlGenerator->generateReleaseUrl($this->sourceUrl, new Version('', '', ''));
         }
 
         return $output;

--- a/tests/resources/FakeUrlGenerator.php
+++ b/tests/resources/FakeUrlGenerator.php
@@ -12,6 +12,7 @@
 namespace Pyrech\ComposerChangelogs\tests\resources;
 
 use Pyrech\ComposerChangelogs\UrlGenerator\UrlGenerator;
+use Pyrech\ComposerChangelogs\Version;
 
 class FakeUrlGenerator implements UrlGenerator
 {
@@ -47,7 +48,7 @@ class FakeUrlGenerator implements UrlGenerator
     /**
      * {@inheritdoc}
      */
-    public function generateCompareUrl($sourceUrl, $versionFrom, $versionTo)
+    public function generateCompareUrl($sourceUrl, Version $versionFrom, Version $versionTo)
     {
         return $this->compareUrl;
     }
@@ -55,7 +56,7 @@ class FakeUrlGenerator implements UrlGenerator
     /**
      * {@inheritdoc}
      */
-    public function generateReleaseUrl($sourceUrl, $version)
+    public function generateReleaseUrl($sourceUrl, Version $version)
     {
         return $this->releaseUrl;
     }


### PR DESCRIPTION
A new Version model was added to keep all the formats created by Composer for a
given version (ie the name used for parsing, the pretty format and a full pretty
format).

This allows to easily detect dev versions and also to keep a reference of the
short commit hash.

Fixes #3