### PR TITLE
Support old Composer versions

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,8 +1,3 @@
-build:
-    tests:
-        override:
-            -
-                command: 'phpunit --coverage-clover=some-file'
-                coverage:
-                    file: 'some-file'
-                    format: 'php-clover'
+tools:
+    external_code_coverage:
+        runs: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,30 @@ cache:
     directories:
         - $HOME/.composer/cache
 
-php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - hhvm
+matrix:
+    include:
+        - php: hhvm
+        - php: 5.4
+        - php: 5.5
+        - php: 5.6
+          env: deps=low coverage=true
+        - php: 5.6
+          env: deps=high coverage=true
+        - php: 7.0
 
-before_script:
-    - composer install --no-interaction
+env:
+    global:
+        - deps=high
+        - coverage=false
+
+install:
+    - if [ "$deps" = "low" ]; then composer --prefer-source --prefer-lowest update; fi;
+    - if [ "$deps" != "low" ]; then composer --prefer-source update; fi;
 
 script:
-    - vendor/bin/phpunit
+    - if [ "$coverage" = "true" ]; then vendor/bin/phpunit --coverage-clover=coverage; fi;
+    - if [ "$coverage" != "true" ]; then vendor/bin/phpunit; fi;
+
+after_script:
+    - if [ "$coverage" = "true" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi;
+    - if [ "$coverage" = "true" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage; fi;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes between versions
 
+## Not yet released
+
+* Add support for old versions of composer (at least v1.0.0-alpha8)
+
 ## 1.1 (2015-10-10)
 
 * Add support for bitbucket repositories

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "fabpot/php-cs-fixer": "~1.5",
-        "composer/composer": "dev-master"
+        "composer/composer": "~1.0.0-alpha10@dev"
     },
     "extra": {
         "class": "Pyrech\\ComposerChangelogs\\ChangelogsPlugin",

--- a/src/OperationHandler/InstallHandler.php
+++ b/src/OperationHandler/InstallHandler.php
@@ -13,6 +13,7 @@ namespace Pyrech\ComposerChangelogs\OperationHandler;
 
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\OperationInterface;
+use Composer\Package\Version\VersionParser;
 use Pyrech\ComposerChangelogs\UrlGenerator\UrlGenerator;
 use Pyrech\ComposerChangelogs\Version;
 
@@ -53,7 +54,9 @@ class InstallHandler implements OperationHandler
         $version = new Version(
             $package->getVersion(),
             $package->getPrettyVersion(),
-            $package->getFullPrettyVersion()
+            method_exists($package, 'getFullPrettyVersion') // This method was added after composer v1.0.0-alpha10
+                ? $package->getFullPrettyVersion()
+                : VersionParser::formatVersion($package)
         );
 
         $output[] = sprintf(

--- a/src/OperationHandler/UninstallHandler.php
+++ b/src/OperationHandler/UninstallHandler.php
@@ -13,6 +13,7 @@ namespace Pyrech\ComposerChangelogs\OperationHandler;
 
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
+use Composer\Package\Version\VersionParser;
 use Pyrech\ComposerChangelogs\UrlGenerator\UrlGenerator;
 use Pyrech\ComposerChangelogs\Version;
 
@@ -53,7 +54,9 @@ class UninstallHandler implements OperationHandler
         $version = new Version(
             $package->getVersion(),
             $package->getPrettyVersion(),
-            $package->getFullPrettyVersion()
+            method_exists($package, 'getFullPrettyVersion') // This method was added after composer v1.0.0-alpha10
+                ? $package->getFullPrettyVersion()
+                : VersionParser::formatVersion($package)
         );
 
         $output[] = sprintf(

--- a/src/OperationHandler/UpdateHandler.php
+++ b/src/OperationHandler/UpdateHandler.php
@@ -13,6 +13,7 @@ namespace Pyrech\ComposerChangelogs\OperationHandler;
 
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UpdateOperation;
+use Composer\Package\Version\VersionParser;
 use Pyrech\ComposerChangelogs\UrlGenerator\UrlGenerator;
 use Pyrech\ComposerChangelogs\Version;
 
@@ -55,12 +56,16 @@ class UpdateHandler implements OperationHandler
         $versionFrom = new Version(
             $initialPackage->getVersion(),
             $initialPackage->getPrettyVersion(),
-            $initialPackage->getFullPrettyVersion()
+            method_exists($initialPackage, 'getFullPrettyVersion') // This method was added after composer v1.0.0-alpha10
+                ? $initialPackage->getFullPrettyVersion()
+                : VersionParser::formatVersion($initialPackage)
         );
         $versionTo = new Version(
             $targetPackage->getVersion(),
             $targetPackage->getPrettyVersion(),
-            $targetPackage->getFullPrettyVersion()
+            method_exists($targetPackage, 'getFullPrettyVersion') // This method was added after composer v1.0.0-alpha10
+                ? $targetPackage->getFullPrettyVersion()
+                : VersionParser::formatVersion($targetPackage)
         );
 
         $output[] = sprintf(

--- a/tests/ChangelogsPluginTest.php
+++ b/tests/ChangelogsPluginTest.php
@@ -73,7 +73,7 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
             new DefaultPolicy(false, false),
             new Pool(),
             new CompositeRepository([]),
-            new Request(),
+            new Request(new Pool()),
             [$operation],
             $operation
         );


### PR DESCRIPTION
Package#getFullPrettyVersion() was added after Composer v1.0.0-alpha10
and replaced VersionParser::formatVersion().

We now support Composer back to version v1.0.0-alpha10 which was
released on 14 apr 2015.

Fixes #8