### PR TITLE
Use `--dev` when requiring locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ composer global require "pyrech/composer-changelogs"
 or locally:
 
 ```shell
-composer require "pyrech/composer-changelogs"
+composer require --dev "pyrech/composer-changelogs"
 ```
 
 ## Usage


### PR DESCRIPTION
It only makes sense to run this script while developing, so adding it to `require-dev` is more appropriate and a better practice IMO.