### PR TITLE
Add support for comparaison across forks and better detect dev versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes between versions
 
+## Not yet released
+
+* Add support for comparison across forks and better detect dev versions ([#19](https://github.com/pyrech/composer-changelogs/pull/19))
+
 ## 1.2 (2015-10-22)
 
 * Add a WordPress url generator for theme and plugin package ([#11](https://github.com/pyrech/composer-changelogs/pull/11))

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "extra": {
         "class": "Pyrech\\ComposerChangelogs\\ChangelogsPlugin",
         "branch-alias": {
-            "dev-master": "1.2.x-dev"
+            "dev-master": "1.3.x-dev"
         }
     },
     "scripts": {

--- a/src/OperationHandler/InstallHandler.php
+++ b/src/OperationHandler/InstallHandler.php
@@ -67,7 +67,7 @@ class InstallHandler implements OperationHandler
 
         if ($urlGenerator) {
             $releaseUrl = $urlGenerator->generateReleaseUrl(
-                $package->getSourceUrl(),
+                $this->extractSourceUrl($operation),
                 $version
             );
 

--- a/src/OperationHandler/UpdateHandler.php
+++ b/src/OperationHandler/UpdateHandler.php
@@ -79,6 +79,7 @@ class UpdateHandler implements OperationHandler
             $compareUrl = $urlGenerator->generateCompareUrl(
                 $initialPackage->getSourceUrl(),
                 $versionFrom,
+                $targetPackage->getSourceUrl(),
                 $versionTo
             );
 
@@ -90,7 +91,7 @@ class UpdateHandler implements OperationHandler
             }
 
             $releaseUrl = $urlGenerator->generateReleaseUrl(
-                $initialPackage->getSourceUrl(),
+                $this->extractSourceUrl($operation),
                 $versionTo
             );
 

--- a/src/UrlGenerator/AbstractUrlGenerator.php
+++ b/src/UrlGenerator/AbstractUrlGenerator.php
@@ -44,7 +44,7 @@ abstract class AbstractUrlGenerator implements UrlGenerator
      */
     protected function isDevVersion(Version $version)
     {
-        return substr($version->getName(), -4) === '-dev';
+        return substr($version->getName(), 0, 4) === 'dev-' || substr($version->getName(), -4) === '-dev';
     }
 
     /**

--- a/src/UrlGenerator/UrlGenerator.php
+++ b/src/UrlGenerator/UrlGenerator.php
@@ -26,13 +26,17 @@ interface UrlGenerator
      * Return the compare url for these versions or false if compare url is not
      * supported.
      *
-     * @param string  $sourceUrl
+     * In case the from and to source urls are different, this probably means
+     * that an across fork compare url should be generated instead.
+     *
+     * @param string  $sourceUrlFrom
      * @param Version $versionFrom
+     * @param string  $sourceUrlTo
      * @param Version $versionTo
      *
      * @return string|false
      */
-    public function generateCompareUrl($sourceUrl, Version $versionFrom, Version $versionTo);
+    public function generateCompareUrl($sourceUrlFrom, Version $versionFrom, $sourceUrlTo, Version $versionTo);
 
     /**
      * Return the release url for the given version or false if compare url is

--- a/src/UrlGenerator/WordPressUrlGenerator.php
+++ b/src/UrlGenerator/WordPressUrlGenerator.php
@@ -31,15 +31,15 @@ class WordPressUrlGenerator implements UrlGenerator
     /**
      * {@inheritdoc}
      */
-    public function generateCompareUrl($sourceUrl, Version $versionFrom, Version $versionTo)
+    public function generateCompareUrl($sourceUrlFrom, Version $versionFrom, $sourceUrlTo, Version $versionTo)
     {
-        if (preg_match('#plugins.svn.wordpress.org/(.*)/#', $sourceUrl, $matches)) {
+        if (preg_match('#plugins.svn.wordpress.org/(.*)/#', $sourceUrlTo, $matches)) {
             $plugin = $matches[1];
 
             return sprintf('https://wordpress.org/plugins/%s/changelog/', $plugin);
         }
 
-        if (preg_match('#themes.svn.wordpress.org/(.*)/#', $sourceUrl, $matches)) {
+        if (preg_match('#themes.svn.wordpress.org/(.*)/#', $sourceUrlTo, $matches)) {
             $theme = $matches[1];
 
             return sprintf('https://themes.trac.wordpress.org/log/%s/', $theme);

--- a/tests/UrlGenerator/BitbucketUrlGeneratorTest.php
+++ b/tests/UrlGenerator/BitbucketUrlGeneratorTest.php
@@ -46,6 +46,7 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateCompareUrl(
                 'https://bitbucket.org/acme/repo',
                 $versionFrom,
+                'https://bitbucket.org/acme/repo',
                 $versionTo
             )
         );
@@ -55,6 +56,7 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateCompareUrl(
                 'https://bitbucket.org/acme/repo.git',
                 $versionFrom,
+                'https://bitbucket.org/acme/repo.git',
                 $versionTo
             )
         );
@@ -70,6 +72,7 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateCompareUrl(
                 'https://bitbucket.org/acme/repo.git',
                 $versionFrom,
+                'https://bitbucket.org/acme/repo.git',
                 $versionTo
             )
         );
@@ -82,8 +85,55 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateCompareUrl(
                 'https://bitbucket.org/acme/repo.git',
                 $versionFrom,
+                'https://bitbucket.org/acme/repo.git',
                 $versionTo
             )
+        );
+
+        $versionFrom = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+        $versionTo   = new Version('dev-fix/issue', 'dev-fix/issue', 'dev-fix/issue 1234abc');
+
+        $this->assertSame(
+            'https://bitbucket.org/acme/repo/branches/compare/1234abc%0Dv1.0.1',
+            $this->SUT->generateCompareUrl(
+                'https://bitbucket.org/acme/repo.git',
+                $versionFrom,
+                'https://bitbucket.org/acme/repo.git',
+                $versionTo
+            )
+        );
+    }
+
+    public function test_it_generates_compare_urls_across_forks()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo   = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertSame(
+            'https://bitbucket.org/acme2/repo/branches/compare/acme2/repo:v1.0.1%0Dacme1/repo:v1.0.0',
+            $this->SUT->generateCompareUrl(
+                'https://bitbucket.org/acme1/repo',
+                $versionFrom,
+                'https://bitbucket.org/acme2/repo',
+                $versionTo
+            )
+        );
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Malformed Bitbucket source url: "https://example.com/url/to/repo"
+     */
+    public function test_it_throws_exception_when_generating_compare_urls_across_forks_if_a_source_url_is_invalid()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo   = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->SUT->generateCompareUrl(
+            'https://bitbucket.org/acme1/repo',
+            $versionFrom,
+            'https://example.com/url/to/repo',
+            $versionTo
         );
     }
 

--- a/tests/UrlGenerator/GithubUrlGeneratorTest.php
+++ b/tests/UrlGenerator/GithubUrlGeneratorTest.php
@@ -46,6 +46,7 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateCompareUrl(
                 'https://github.com/acme/repo',
                 $versionFrom,
+                'https://github.com/acme/repo',
                 $versionTo
             )
         );
@@ -55,6 +56,7 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateCompareUrl(
                 'https://github.com/acme/repo.git',
                 $versionFrom,
+                'https://github.com/acme/repo.git',
                 $versionTo
             )
         );
@@ -70,6 +72,7 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateCompareUrl(
                 'https://github.com/acme/repo.git',
                 $versionFrom,
+                'https://github.com/acme/repo.git',
                 $versionTo
             )
         );
@@ -82,8 +85,55 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateCompareUrl(
                 'https://github.com/acme/repo.git',
                 $versionFrom,
+                'https://github.com/acme/repo.git',
                 $versionTo
             )
+        );
+
+        $versionFrom = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+        $versionTo   = new Version('dev-fix/issue', 'dev-fix/issue', 'dev-fix/issue 1234abc');
+
+        $this->assertSame(
+            'https://github.com/acme/repo/compare/v1.0.1...1234abc',
+            $this->SUT->generateCompareUrl(
+                'https://github.com/acme/repo.git',
+                $versionFrom,
+                'https://github.com/acme/repo.git',
+                $versionTo
+            )
+        );
+    }
+
+    public function test_it_generates_compare_urls_across_forks()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo   = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertSame(
+            'https://github.com/acme2/repo/compare/acme1:v1.0.0...acme2:v1.0.1',
+            $this->SUT->generateCompareUrl(
+                'https://github.com/acme1/repo',
+                $versionFrom,
+                'https://github.com/acme2/repo',
+                $versionTo
+            )
+        );
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Malformed Github source url: "https://example.com/url/to/repo"
+     */
+    public function test_it_throws_exception_when_generating_compare_urls_across_forks_if_a_source_url_is_invalid()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo   = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->SUT->generateCompareUrl(
+            'https://github.com/acme1/repo',
+            $versionFrom,
+            'https://example.com/url/to/repo',
+            $versionTo
         );
     }
 
@@ -93,6 +143,13 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateReleaseUrl(
                 'https://github.com/acme/repo',
                 new Version('9999999-dev', 'dev-master', 'dev-master 1234abc')
+            )
+        );
+
+        $this->assertFalse(
+            $this->SUT->generateReleaseUrl(
+                'https://github.com/acme/repo',
+                new Version('dev-fix/issue', 'dev-fix/issue', 'dev-fix/issue 1234abc')
             )
         );
     }

--- a/tests/UrlGenerator/WordPressUrlGeneratorTest.php
+++ b/tests/UrlGenerator/WordPressUrlGeneratorTest.php
@@ -51,6 +51,7 @@ class WordPressUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateCompareUrl(
                 'http://plugins.svn.wordpress.org/askimet/',
                 $versionFrom,
+                'http://plugins.svn.wordpress.org/askimet/',
                 $versionTo
             )
         );
@@ -60,6 +61,7 @@ class WordPressUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateCompareUrl(
                 'http://themes.svn.wordpress.org/minimize/',
                 $versionFrom,
+                'http://themes.svn.wordpress.org/minimize/',
                 $versionTo
             )
         );

--- a/tests/resources/FakeHandler.php
+++ b/tests/resources/FakeHandler.php
@@ -69,7 +69,7 @@ class FakeHandler implements OperationHandler
         ];
 
         if ($urlGenerator) {
-            $output[] = '   '.$urlGenerator->generateCompareUrl($this->sourceUrl, new Version('', '', ''), new Version('', '', ''));
+            $output[] = '   '.$urlGenerator->generateCompareUrl($this->sourceUrl, new Version('', '', ''), $this->sourceUrl, new Version('', '', ''));
             $output[] = '   '.$urlGenerator->generateReleaseUrl($this->sourceUrl, new Version('', '', ''));
         }
 

--- a/tests/resources/FakeUrlGenerator.php
+++ b/tests/resources/FakeUrlGenerator.php
@@ -48,7 +48,7 @@ class FakeUrlGenerator implements UrlGenerator
     /**
      * {@inheritdoc}
      */
-    public function generateCompareUrl($sourceUrl, Version $versionFrom, Version $versionTo)
+    public function generateCompareUrl($sourceUrlFrom, Version $versionFrom, $sourceUrlTo, Version $versionTo)
     {
         return $this->compareUrl;
     }


### PR DESCRIPTION
Source urls of both packages (original and target) of an update operation
are now passed to the url generator. It allows to detect when a fork is used.

Additionally dev versions are better detected (branch prefixed with "dev-"
was not considered as dev).

Fixes #18