### PR TITLE
Introduce GitBasedUrlGenerator abstract class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add support for bitbucket ssh urls ([#27](https://github.com/pyrech/composer-changelogs/pull/27))
 * Fix tests with newer composer versions ([#28](https://github.com/pyrech/composer-changelogs/pull/28))
 * Fix bug when switching from a local repository back to the original repository ([#30](https://github.com/pyrech/composer-changelogs/pull/30))
+* Add GitBasedUrlGenerator to replace AbstractUrlGenerator ([#20](https://github.com/pyrech/composer-changelogs/pull/20))
 
 ## 1.3 (2015-11-13)
 

--- a/src/UrlGenerator/AbstractUrlGenerator.php
+++ b/src/UrlGenerator/AbstractUrlGenerator.php
@@ -13,58 +13,22 @@ namespace Pyrech\ComposerChangelogs\UrlGenerator;
 
 use Pyrech\ComposerChangelogs\Version;
 
-abstract class AbstractUrlGenerator implements UrlGenerator
+/**
+ * @deprecated since v1.4, will be removed in v2.0. Use GitBasedUrlGenerator class instead.
+ */
+abstract class AbstractUrlGenerator extends GitBasedUrlGenerator
 {
-    /**
-     * Generates the base url for a repository by removing the .git part.
-     *
-     * @param string $sourceUrl
-     *
-     * @return string
-     */
-    protected function generateBaseUrl($sourceUrl)
-    {
-        $sourceUrl = parse_url($sourceUrl);
-        $pos = strrpos($sourceUrl['path'], '.git');
-
-        return sprintf(
-            '%s://%s%s',
-            $sourceUrl['scheme'],
-            $sourceUrl['host'],
-            $pos === false ? $sourceUrl['path'] : substr($sourceUrl['path'], 0, strrpos($sourceUrl['path'], '.git'))
-        );
-    }
-
     /**
      * Return whether the version is dev or not.
      *
      * @param Version $version
      *
      * @return string
+     *
+     * @deprecated since v1.4, will be removed in v2.0. Use $version->isDev() instead.
      */
     protected function isDevVersion(Version $version)
     {
-        return substr($version->getName(), 0, 4) === 'dev-' || substr($version->getName(), -4) === '-dev';
-    }
-
-    /**
-     * Get the version to use for the compare url.
-     *
-     * For dev versions, it returns the commit short hash in full pretty version.
-     *
-     * @param Version $version
-     *
-     * @return string
-     */
-    protected function getCompareVersion(Version $version)
-    {
-        if ($this->isDevVersion($version)) {
-            return substr(
-                $version->getFullPretty(),
-                strlen($version->getPretty()) + 1
-            );
-        }
-
-        return $version->getPretty();
+        return $version->isDev();
     }
 }

--- a/src/UrlGenerator/GitBasedUrlGenerator.php
+++ b/src/UrlGenerator/GitBasedUrlGenerator.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the composer-changelogs project.
+ *
+ * (c) Loïck Piera <pyrech@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pyrech\ComposerChangelogs\UrlGenerator;
+
+use Pyrech\ComposerChangelogs\Version;
+
+abstract class GitBasedUrlGenerator implements UrlGenerator
+{
+    /**
+     * Generates the base url for a repository by removing the .git part.
+     *
+     * @param string $sourceUrl
+     *
+     * @return string
+     */
+    protected function generateBaseUrl($sourceUrl)
+    {
+        $sourceUrl = parse_url($sourceUrl);
+        $pos = strrpos($sourceUrl['path'], '.git');
+
+        return sprintf(
+            '%s://%s%s',
+            $sourceUrl['scheme'],
+            $sourceUrl['host'],
+            $pos === false ? $sourceUrl['path'] : substr($sourceUrl['path'], 0, strrpos($sourceUrl['path'], '.git'))
+        );
+    }
+
+    /**
+     * Get the version to use for the compare url.
+     *
+     * For dev versions, it returns the commit short hash in full pretty version.
+     *
+     * @param Version $version
+     *
+     * @return string
+     */
+    protected function getCompareVersion(Version $version)
+    {
+        if ($version->isDev()) {
+            return substr(
+                $version->getFullPretty(),
+                strlen($version->getPretty()) + 1
+            );
+        }
+
+        return $version->getPretty();
+    }
+}

--- a/src/UrlGenerator/GithubUrlGenerator.php
+++ b/src/UrlGenerator/GithubUrlGenerator.php
@@ -68,7 +68,7 @@ class GithubUrlGenerator extends AbstractUrlGenerator
      */
     public function generateReleaseUrl($sourceUrl, Version $version)
     {
-        if ($this->isDevVersion($version)) {
+        if ($version->isDev()) {
             return false;
         }
 

--- a/src/Version.php
+++ b/src/Version.php
@@ -57,4 +57,14 @@ class Version
     {
         return $this->fullPretty;
     }
+
+    /**
+     * Return whether the version is dev or not.
+     *
+     * @return string
+     */
+    public function isDev()
+    {
+        return substr($this->name, 0, 4) === 'dev-' || substr($this->name, -4) === '-dev';
+    }
 }

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the composer-changelogs project.
+ *
+ * (c) Loïck Piera <pyrech@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pyrech\ComposerChangelogs\tests;
+
+use Pyrech\ComposerChangelogs\Version;
+
+class VersionTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Version */
+    private $SUT;
+
+    public function test_it_keep_version_formats()
+    {
+        $this->SUT = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+
+        $this->assertSame('v1.0.0.0', $this->SUT->getName());
+        $this->assertSame('v1.0.0', $this->SUT->getPretty());
+        $this->assertSame('v1.0.0', $this->SUT->getFullPretty());
+
+        $this->SUT = new Version('v.1.0.9999999.9999999-dev', 'dev-master', 'dev-master 1234abc');
+
+        $this->assertSame('v.1.0.9999999.9999999-dev', $this->SUT->getName());
+        $this->assertSame('dev-master', $this->SUT->getPretty());
+        $this->assertSame('dev-master 1234abc', $this->SUT->getFullPretty());
+    }
+
+    public function test_it_detects_dev_version()
+    {
+        $this->SUT = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+
+        $this->assertFalse($this->SUT->isDev());
+
+        $this->SUT = new Version('v.1.0.9999999.9999999-dev', 'dev-master', 'dev-master 1234abc');
+
+        $this->assertTrue($this->SUT->isDev());
+
+        $this->SUT = new Version('dev-fix/issue', 'dev-fix/issue', 'dev-fix/issue 1234abc');
+
+        $this->assertTrue($this->SUT->isDev());
+    }
+}


### PR DESCRIPTION
Move the dev version detection logic to Version#isDev().
AbstractUrlGenerator class will be removed in v2.0.