### PR TITLE
Autoload all the classes required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not yet released
 
 * Add support for comparison across forks and better detect dev versions ([#19](https://github.com/pyrech/composer-changelogs/pull/19))
+* Add autoloading of classes required to make the plugin always working ([#22](https://github.com/pyrech/composer-changelogs/pull/22))
 
 ## 1.2 (2015-10-22)
 

--- a/src/ChangelogsPlugin.php
+++ b/src/ChangelogsPlugin.php
@@ -35,6 +35,8 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
     {
         $this->io        = $io;
         $this->outputter = Factory::createOutputter();
+
+        $this->autoloadNeededClasses();
     }
 
     /**
@@ -74,5 +76,27 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
     public function postUpdate(Event $event)
     {
         $this->io->write($this->outputter->getOutput());
+    }
+
+    /**
+     * This method ensures all the classes required to make the plugin working
+     * are loaded.
+     *
+     * It's required to avoid composer looking for classes no longer existing
+     * (after the plugin is updated or removed for example).
+     *
+     * All operation handlers, url generators and Outputter classes do not
+     * need this because they are already autoloaded by the Factory.
+     */
+    private function autoloadNeededClasses()
+    {
+        $classes = [
+            'Pyrech\ComposerChangelogs\Version',
+        ];
+
+        foreach ($classes as $class) {
+            // Force the class to be autoloaded
+            class_exists($class, true);
+        }
     }
 }


### PR DESCRIPTION
This prevents Composer to try loading classes no longer existing after the plugin
is updated or removed.

It will requires to keep up to date the list of classes (but unlikely to change
really often) and is the simpler trick to avoid these weird errors.

Fixes #10
Fixes #14