### PR TITLE
Fix/unittest fail due to use of private method

### DIFF
--- a/tests/ChangelogsPluginTest.php
+++ b/tests/ChangelogsPluginTest.php
@@ -48,6 +48,10 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_is_registered_and_activated()
     {
+        if (! is_callable([$this->composer->getPluginManager(), 'addPlugin'])) {
+            $this->markTestSkipped('Newer versions of composer have no public addPlugin method');
+        }
+
         $plugin = new ChangelogsPlugin();
         $this->composer->getPluginManager()->addPlugin($plugin);
         $this->assertSame([$plugin], $this->composer->getPluginManager()->getPlugins());
@@ -57,6 +61,10 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_receives_event()
     {
+        if (! is_callable([$this->composer->getPluginManager(), 'addPlugin'])) {
+            $this->markTestSkipped('Newer versions of composer have no public addPlugin method');
+        }
+
         $this->composer->getPluginManager()->addPlugin(new ChangelogsPlugin());
 
         $initialPackage = new Package('foo/bar', '1.0.0.0', 'v1.0.0');

--- a/tests/ChangelogsPluginTest.php
+++ b/tests/ChangelogsPluginTest.php
@@ -50,7 +50,7 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_is_registered_and_activated()
     {
-        if (! is_callable([$this->composer->getPluginManager(), 'addPlugin'])) {
+        if (!is_callable([$this->composer->getPluginManager(), 'addPlugin'])) {
             $this->markTestSkipped('Newer versions of composer have no public addPlugin method');
         }
 
@@ -63,7 +63,7 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_receives_event()
     {
-        if (! is_callable([$this->composer->getPluginManager(), 'addPlugin'])) {
+        if (!is_callable([$this->composer->getPluginManager(), 'addPlugin'])) {
             $this->markTestSkipped('Newer versions of composer have no public addPlugin method');
         }
 


### PR DESCRIPTION
Marked the failing test as skipped when a recent version of composer is used in the test environment.

Created a new test method to test the plugin code without relying on the internals of composer.