### PR TITLE
Fix compare url generation for unsupported urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update coding standards ([#25](https://github.com/pyrech/composer-changelogs/pull/25))
 * Add support for bitbucket ssh urls ([#27](https://github.com/pyrech/composer-changelogs/pull/27))
 * Fix tests with newer composer versions ([#28](https://github.com/pyrech/composer-changelogs/pull/28))
+* Fix bug when switching from a local repository back to the original repository ([#30](https://github.com/pyrech/composer-changelogs/pull/30))
 
 ## 1.3 (2015-11-13)
 

--- a/src/UrlGenerator/BitbucketUrlGenerator.php
+++ b/src/UrlGenerator/BitbucketUrlGenerator.php
@@ -32,6 +32,12 @@ class BitbucketUrlGenerator extends AbstractUrlGenerator
      */
     public function generateCompareUrl($sourceUrlFrom, Version $versionFrom, $sourceUrlTo, Version $versionTo)
     {
+        // Check if both urls come from the supported domain
+        // It avoids problems when one url is from another domain or is local
+        if (!$this->supports($sourceUrlFrom) || !$this->supports($sourceUrlTo)) {
+            return false;
+        }
+
         $sourceUrlFrom = $this->generateBaseUrl($this->reformatSshUrl($sourceUrlFrom));
         $sourceUrlTo = $this->generateBaseUrl($this->reformatSshUrl($sourceUrlTo));
 

--- a/src/UrlGenerator/GithubUrlGenerator.php
+++ b/src/UrlGenerator/GithubUrlGenerator.php
@@ -31,6 +31,12 @@ class GithubUrlGenerator extends AbstractUrlGenerator
      */
     public function generateCompareUrl($sourceUrlFrom, Version $versionFrom, $sourceUrlTo, Version $versionTo)
     {
+        // Check if both urls come from the supported domain
+        // It avoids problems when one url is from another domain or is local
+        if (!$this->supports($sourceUrlFrom) || !$this->supports($sourceUrlTo)) {
+            return false;
+        }
+
         $sourceUrlFrom = $this->generateBaseUrl($sourceUrlFrom);
         $sourceUrlTo = $this->generateBaseUrl($sourceUrlTo);
 

--- a/tests/UrlGenerator/BitbucketUrlGeneratorTest.php
+++ b/tests/UrlGenerator/BitbucketUrlGeneratorTest.php
@@ -121,9 +121,33 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function test_it_does_not_generate_compare_urls_for_unsupported_url()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertFalse(
+            $this->SUT->generateCompareUrl(
+                '/home/toto/work/my-package',
+                $versionFrom,
+                'https://bitbucket.org/acme2/repo',
+                $versionTo
+            )
+        );
+
+        $this->assertFalse(
+            $this->SUT->generateCompareUrl(
+                'https://bitbucket.org/acme1/repo',
+                $versionFrom,
+                '/home/toto/work/my-package',
+                $versionTo
+            )
+        );
+    }
+
     /**
      * @expectedException \LogicException
-     * @expectedExceptionMessage Malformed Bitbucket source url: "https://example.com/url/to/repo"
+     * @expectedExceptionMessage Malformed Bitbucket source url: "https://bitbucket.org/acme2"
      */
     public function test_it_throws_exception_when_generating_compare_urls_across_forks_if_a_source_url_is_invalid()
     {
@@ -133,7 +157,7 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->SUT->generateCompareUrl(
             'https://bitbucket.org/acme1/repo',
             $versionFrom,
-            'https://example.com/url/to/repo',
+            'https://bitbucket.org/acme2',
             $versionTo
         );
     }

--- a/tests/UrlGenerator/GithubUrlGeneratorTest.php
+++ b/tests/UrlGenerator/GithubUrlGeneratorTest.php
@@ -120,9 +120,33 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function test_it_does_not_generate_compare_urls_for_unsupported_url()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertFalse(
+            $this->SUT->generateCompareUrl(
+                '/home/toto/work/my-package',
+                $versionFrom,
+                'https://github.com/acme2/repo',
+                $versionTo
+            )
+        );
+
+        $this->assertFalse(
+            $this->SUT->generateCompareUrl(
+                'https://github.com/acme1/repo',
+                $versionFrom,
+                '/home/toto/work/my-package',
+                $versionTo
+            )
+        );
+    }
+
     /**
      * @expectedException \LogicException
-     * @expectedExceptionMessage Malformed Github source url: "https://example.com/url/to/repo"
+     * @expectedExceptionMessage Malformed Github source url: "https://github.com/acme2"
      */
     public function test_it_throws_exception_when_generating_compare_urls_across_forks_if_a_source_url_is_invalid()
     {
@@ -132,7 +156,7 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->SUT->generateCompareUrl(
             'https://github.com/acme1/repo',
             $versionFrom,
-            'https://example.com/url/to/repo',
+            'https://github.com/acme2',
             $versionTo
         );
     }


### PR DESCRIPTION
This should fix the problem when switching from a local repository back to
the original repository.
Now source url of both origin and target packages should be supported to be
able to generate a compare url.

Should fix #23