### PR TITLE
Add support for Github ssh urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix bug when switching from a local repository back to the original repository ([#30](https://github.com/pyrech/composer-changelogs/pull/30))
 * Add GitBasedUrlGenerator to replace AbstractUrlGenerator ([#20](https://github.com/pyrech/composer-changelogs/pull/20))
 * Add experimental autocommit feature ([#29](https://github.com/pyrech/composer-changelogs/pull/29))
+* Add support for github ssh urls ([#32](https://github.com/pyrech/composer-changelogs/pull/32))
 
 ## 1.3 (2015-11-13)
 

--- a/src/UrlGenerator/BitbucketUrlGenerator.php
+++ b/src/UrlGenerator/BitbucketUrlGenerator.php
@@ -15,16 +15,12 @@ use Pyrech\ComposerChangelogs\Version;
 
 class BitbucketUrlGenerator extends AbstractUrlGenerator
 {
-    const DOMAIN = 'bitbucket.org';
-    const URL_REGEX = '@bitbucket.org/(?P<user>[^/]+)/(?P<repository>[^/]+)@';
-    const SSH_REGEX = '/^git@bitbucket\.org:(?P<user>[^\/]+)\/(?P<repository>.+)\.git$/';
-
     /**
      * {@inheritdoc}
      */
-    public function supports($sourceUrl)
+    protected function getDomain()
     {
-        return strpos($sourceUrl, self::DOMAIN) !== false;
+        return 'bitbucket.org';
     }
 
     /**
@@ -38,8 +34,8 @@ class BitbucketUrlGenerator extends AbstractUrlGenerator
             return false;
         }
 
-        $sourceUrlFrom = $this->generateBaseUrl($this->reformatSshUrl($sourceUrlFrom));
-        $sourceUrlTo = $this->generateBaseUrl($this->reformatSshUrl($sourceUrlTo));
+        $sourceUrlFrom = $this->generateBaseUrl($sourceUrlFrom);
+        $sourceUrlTo = $this->generateBaseUrl($sourceUrlTo);
 
         // Check if comparison across forks is needed
         if ($sourceUrlFrom !== $sourceUrlTo) {
@@ -73,44 +69,5 @@ class BitbucketUrlGenerator extends AbstractUrlGenerator
     {
         // Releases are not supported on Bitbucket :'(
         return false;
-    }
-
-    /**
-     * @param string $sourceUrl
-     *
-     * @return array
-     */
-    private function extractRepositoryInformation($sourceUrl)
-    {
-        preg_match(self::URL_REGEX, $sourceUrl, $matches);
-
-        if (!isset($matches['user']) || !isset($matches['repository'])) {
-            throw new \LogicException(
-                sprintf('Malformed Bitbucket source url: "%s"', $sourceUrl)
-            );
-        }
-
-        return [
-            'user' => $matches['user'],
-            'repository' => $matches['repository'],
-        ];
-    }
-
-    /**
-     * @param string $url
-     *
-     * @return string
-     */
-    private function reformatSshUrl($url)
-    {
-        if (preg_match(self::SSH_REGEX, $url, $matches)) {
-            return sprintf(
-                'https://bitbucket.org/%s/%s',
-                $matches['user'],
-                $matches['repository']
-            );
-        }
-
-        return $url;
     }
 }

--- a/src/UrlGenerator/GitBasedUrlGenerator.php
+++ b/src/UrlGenerator/GitBasedUrlGenerator.php
@@ -15,8 +15,29 @@ use Pyrech\ComposerChangelogs\Version;
 
 abstract class GitBasedUrlGenerator implements UrlGenerator
 {
+    const REGEX_USER = '(?P<user>[^/]+)';
+    const REGEX_REPOSITORY = '(?P<repository>[^/]+)';
+
     /**
-     * Generates the base url for a repository by removing the .git part.
+     * Returns the domain of the service, like "example.org".
+     *
+     * @return string
+     */
+    abstract protected function getDomain();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($sourceUrl)
+    {
+        return strpos($sourceUrl, $this->getDomain()) !== false;
+    }
+
+    /**
+     * Generates the canonical http url for a repository.
+     *
+     * It ensures there is no .git part in http url. It also supports ssh urls
+     * by converting them in their http equivalent format.
      *
      * @param string $sourceUrl
      *
@@ -24,6 +45,10 @@ abstract class GitBasedUrlGenerator implements UrlGenerator
      */
     protected function generateBaseUrl($sourceUrl)
     {
+        if ($this->isSshUrl($sourceUrl)) {
+            return $this->transformSshUrlIntoHttp($sourceUrl);
+        }
+
         $sourceUrl = parse_url($sourceUrl);
         $pos = strrpos($sourceUrl['path'], '.git');
 
@@ -54,5 +79,65 @@ abstract class GitBasedUrlGenerator implements UrlGenerator
         }
 
         return $version->getPretty();
+    }
+
+    /**
+     * Extracts information like user and repository from the http url.
+     *
+     * @param string $sourceUrl
+     *
+     * @return array
+     */
+    protected function extractRepositoryInformation($sourceUrl)
+    {
+        $pattern = '#' . $this->getDomain() . '/' . self::REGEX_USER . '/' . self::REGEX_REPOSITORY . '#';
+
+        preg_match($pattern, $sourceUrl, $matches);
+
+        if (!isset($matches['user']) || !isset($matches['repository'])) {
+            throw new \LogicException(
+                sprintf('Unrecognized url format for %s ("%s")', $this->getDomain(), $sourceUrl)
+            );
+        }
+
+        return [
+            'user' => $matches['user'],
+            'repository' => $matches['repository'],
+        ];
+    }
+
+    /**
+     * Returns whether an url uses a ssh git protocol.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    private function isSshUrl($url)
+    {
+        return strpos($url, 'git@') !== false;
+    }
+
+    /**
+     * Transform an ssh git url into an http one.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    private function transformSshUrlIntoHttp($url)
+    {
+        $pattern = '#git@' . $this->getDomain() . ':' . self::REGEX_USER . '/' . self::REGEX_REPOSITORY . '.git$#';
+
+        if (preg_match($pattern, $url, $matches)) {
+            return sprintf(
+                'https://%s/%s/%s',
+                $this->getDomain(),
+                $matches['user'],
+                $matches['repository']
+            );
+        }
+
+        return $url;
     }
 }

--- a/src/UrlGenerator/GithubUrlGenerator.php
+++ b/src/UrlGenerator/GithubUrlGenerator.php
@@ -15,15 +15,12 @@ use Pyrech\ComposerChangelogs\Version;
 
 class GithubUrlGenerator extends AbstractUrlGenerator
 {
-    const DOMAIN = 'github.com';
-    const URL_REGEX = '@github.com/(?P<user>[^/]+)/(?P<repository>[^/]+)@';
-
     /**
      * {@inheritdoc}
      */
-    public function supports($sourceUrl)
+    protected function getDomain()
     {
-        return strpos($sourceUrl, self::DOMAIN) !== false;
+        return 'github.com';
     }
 
     /**
@@ -42,15 +39,15 @@ class GithubUrlGenerator extends AbstractUrlGenerator
 
         // Check if comparison across forks is needed
         if ($sourceUrlFrom !== $sourceUrlTo) {
-            $userFrom = $this->extractUser($sourceUrlFrom);
-            $userTo = $this->extractUser($sourceUrlTo);
+            $repositoryFrom = $this->extractRepositoryInformation($sourceUrlFrom);
+            $repositoryTo = $this->extractRepositoryInformation($sourceUrlTo);
 
             return sprintf(
                 '%s/compare/%s:%s...%s:%s',
                 $sourceUrlTo,
-                $userFrom,
+                $repositoryFrom['user'],
                 $this->getCompareVersion($versionFrom),
-                $userTo,
+                $repositoryTo['user'],
                 $this->getCompareVersion($versionTo)
             );
         }
@@ -77,23 +74,5 @@ class GithubUrlGenerator extends AbstractUrlGenerator
             $this->generateBaseUrl($sourceUrl),
             $version->getPretty()
         );
-    }
-
-    /**
-     * @param string $sourceUrl
-     *
-     * @¶eturn string
-     */
-    private function extractUser($sourceUrl)
-    {
-        preg_match(self::URL_REGEX, $sourceUrl, $matches);
-
-        if (!isset($matches['user'])) {
-            throw new \LogicException(
-                sprintf('Malformed Github source url: "%s"', $sourceUrl)
-            );
-        }
-
-        return $matches['user'];
     }
 }

--- a/tests/UrlGenerator/BitbucketUrlGeneratorTest.php
+++ b/tests/UrlGenerator/BitbucketUrlGeneratorTest.php
@@ -147,7 +147,7 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \LogicException
-     * @expectedExceptionMessage Malformed Bitbucket source url: "https://bitbucket.org/acme2"
+     * @expectedExceptionMessage Unrecognized url format for bitbucket.org ("https://bitbucket.org/acme2")
      */
     public function test_it_throws_exception_when_generating_compare_urls_across_forks_if_a_source_url_is_invalid()
     {
@@ -159,6 +159,22 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $versionFrom,
             'https://bitbucket.org/acme2',
             $versionTo
+        );
+    }
+
+    public function test_it_generates_compare_urls_with_ssh_source_url()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertSame(
+            'https://bitbucket.org/acme/repo/branches/compare/v1.0.1%0Dv1.0.0',
+            $this->SUT->generateCompareUrl(
+                'git@bitbucket.org:acme/repo.git',
+                $versionFrom,
+                'git@bitbucket.org:acme/repo.git',
+                $versionTo
+            )
         );
     }
 
@@ -175,22 +191,6 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->SUT->generateReleaseUrl(
                 'https://bitbucket.org/acme/repo.git',
                 new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1')
-            )
-        );
-    }
-
-    public function test_it_generates_compare_urls_with_ssh_source_url()
-    {
-        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
-        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
-
-        $this->assertSame(
-            'https://bitbucket.org/acme/repo/branches/compare/v1.0.1%0Dv1.0.0',
-            $this->SUT->generateCompareUrl(
-                'git@bitbucket.org:acme/repo.git',
-                $versionFrom,
-                'git@bitbucket.org:acme/repo.git',
-                $versionTo
             )
         );
     }

--- a/tests/UrlGenerator/GithubUrlGeneratorTest.php
+++ b/tests/UrlGenerator/GithubUrlGeneratorTest.php
@@ -28,6 +28,7 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->SUT->supports('https://github.com/phpunit/phpunit-mock-objects.git'));
         $this->assertTrue($this->SUT->supports('https://github.com/symfony/console'));
+        $this->assertTrue($this->SUT->supports('git@github.com:private/repo.git'));
     }
 
     public function test_it_does_not_support_non_github_urls()
@@ -146,7 +147,7 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \LogicException
-     * @expectedExceptionMessage Malformed Github source url: "https://github.com/acme2"
+     * @expectedExceptionMessage Unrecognized url format for github.com ("https://github.com/acme2")
      */
     public function test_it_throws_exception_when_generating_compare_urls_across_forks_if_a_source_url_is_invalid()
     {
@@ -158,6 +159,22 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             $versionFrom,
             'https://github.com/acme2',
             $versionTo
+        );
+    }
+
+    public function test_it_generates_compare_urls_with_ssh_source_url()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertSame(
+            'https://github.com/acme/repo/compare/v1.0.0...v1.0.1',
+            $this->SUT->generateCompareUrl(
+                'git@github.com:acme/repo.git',
+                $versionFrom,
+                'git@github.com:acme/repo.git',
+                $versionTo
+            )
         );
     }
 
@@ -192,6 +209,17 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
             'https://github.com/acme/repo/releases/tag/v1.0.1',
             $this->SUT->generateReleaseUrl(
                 'https://github.com/acme/repo.git',
+                new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1')
+            )
+        );
+    }
+
+    public function test_it_generates_release_url_with_ssh_source_url()
+    {
+        $this->assertSame(
+            'https://github.com/acme/repo/releases/tag/v1.0.1',
+            $this->SUT->generateReleaseUrl(
+                'git@github.com:acme/repo.git',
                 new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1')
             )
         );


### PR DESCRIPTION
This should fix #31.

Additionnaly GitBasedUrlGenerator was refactored a bit to mutualize
code between Github and Bitbucket url generators.