### PR TITLE
Add new config "commit-message"

### DIFF
--- a/doc/autocommit.md
+++ b/doc/autocommit.md
@@ -19,7 +19,8 @@ some `extra` config in your composer.json:
     "extra": {
         "composer-changelogs": {
             "commit-auto": "ask",
-            "commit-bin-file": "path/to/bin"
+            "commit-bin-file": "path/to/bin",
+            "commit-message": "First line of commit message"
         }
     }
 }
@@ -69,3 +70,9 @@ one requiring the plugin):
     }
 }
 ```
+
+### commit-message
+
+This option can override the first line of the default commit message. If the
+setting is omitted or the value is empty, the default message is used:
+> Update dependencies

--- a/src/ChangelogsPlugin.php
+++ b/src/ChangelogsPlugin.php
@@ -166,7 +166,7 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
 
         $workingDirectory = getcwd();
         $filename = tempnam(sys_get_temp_dir(), 'composer-changelogs-');
-        $message = 'Update dependencies' . PHP_EOL . PHP_EOL . strip_tags($this->outputter->getOutput());
+        $message = $this->config->getCommitMessage() . PHP_EOL . PHP_EOL . strip_tags($this->outputter->getOutput());
 
         file_put_contents($filename, $message);
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -19,14 +19,19 @@ class Config
     /** @var string|null */
     private $commitBinFile;
 
+    /** @var string */
+    private $commitMessage;
+
     /**
      * @param string      $commitAuto
      * @param string|null $commitBinFile
+     * @param string      $commitMessage
      */
-    public function __construct($commitAuto, $commitBinFile)
+    public function __construct($commitAuto, $commitBinFile, $commitMessage)
     {
         $this->commitAuto = $commitAuto;
         $this->commitBinFile = $commitBinFile;
+        $this->commitMessage = $commitMessage;
     }
 
     /**
@@ -43,5 +48,13 @@ class Config
     public function getCommitBinFile()
     {
         return $this->commitBinFile;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCommitMessage()
+    {
+        return $this->commitMessage;
     }
 }

--- a/src/Config/ConfigBuilder.php
+++ b/src/Config/ConfigBuilder.php
@@ -36,6 +36,7 @@ class ConfigBuilder
 
         $commitAuto = 'never';
         $commitBinFile = null;
+        $commitMessage = 'Update dependencies';
 
         if (array_key_exists('commit-auto', $extra)) {
             if (in_array($extra['commit-auto'], self::$validCommitAutoValues, true)) {
@@ -75,7 +76,15 @@ class ConfigBuilder
             }
         }
 
-        return new Config($commitAuto, $commitBinFile);
+        if (array_key_exists('commit-message', $extra)) {
+            if (strlen(trim($extra['commit-message'])) === 0) {
+                $this->warnings[] = '"commit-message" is specified but empty. Ignoring and using default commit message.';
+            } else {
+                $commitMessage = $extra['commit-message'];
+            }
+        }
+
+        return new Config($commitAuto, $commitBinFile, $commitMessage);
     }
 
     /**

--- a/tests/fixtures/bin/fake.sh
+++ b/tests/fixtures/bin/fake.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-echo "this is a task"
+FAKE_BIN_DIR=$(dirname $0)
+TEST_DIR=$FAKE_BIN_DIR/../../temp
+MESSAGE_FILE=$TEST_DIR/commit-message.txt
+cat "$2" > $MESSAGE_FILE

--- a/tests/fixtures/home-commit-message/composer.json
+++ b/tests/fixtures/home-commit-message/composer.json
@@ -1,0 +1,12 @@
+{
+    "extra": {
+        "composer-changelogs": {
+            "commit-auto": "always",
+            "commit-bin-file": "../bin/fake.sh",
+            "commit-message": "chore: Update composer"
+        },
+        "my-global-config": {
+            "bar": "foo"
+        }
+    }
+}


### PR DESCRIPTION
Hi! I've added a new config option, passing tests included.

To test the commit message used, I modified `fake.sh` to redirect the message to a local temp file.

It should be fully backward compatible, as it falls back to the current default message.

Taken straight from commit.md:
* * * *
### commit-message

This option can override the first line of the default commit message. If the
setting is omitted or the value is empty, the default message is used:
> Update dependencies