### PR TITLE
Add support for gitlab repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add better description for downgrade operations ([#39](https://github.com/pyrech/composer-changelogs/pull/39))
 * Remove tests skipping ([#38](https://github.com/pyrech/composer-changelogs/pull/38))
+* Add support for gitlab repositories ([#37](https://github.com/pyrech/composer-changelogs/pull/37))
 
 ## 1.4 (2016-03-21)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you no longer want to display summary, you can either:
 
 Here is some documentation about the project:
 
+* [Configuration, like gitlab hosts setup](doc/configuration.md)
 * [Experimental autocommit feature](doc/autocommit.md)
 
 You can see the current and past versions using one of the following:

--- a/doc/autocommit.md
+++ b/doc/autocommit.md
@@ -26,12 +26,9 @@ some `extra` config in your composer.json:
 }
 ```
 
-### Config location
+> See [this documentation](configuration.md) for where to put your config.
 
-This `composer-changelogs` extra config can be put either in your local
-`composer.json` (the one of the project you are working on) or the global
-one in your `.composer` home directory (like
-`/home/{user}/.composer/composer.json` on Linux).
+## Options available
 
 ### commit-auto
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,0 +1,54 @@
+# Plugin configuration
+
+This plugin supports some configuration - for example to specify the gitlab
+hosts it should detect.
+
+## Location
+
+Configuration can be setup by adding parameters in the `extra` section of your
+`composer.json`.
+
+```json
+{
+    "extra": {
+        "composer-changelogs": {
+            "{{ the configuration key }}": "{{ the configuration value }}",
+        }
+    }
+}
+```
+
+This `composer-changelogs` extra config can be put either in your local
+`composer.json` (the one of the project you are working on) or the global
+one in your `.composer` home directory (like
+`/home/{user}/.composer/composer.json` on Linux).
+
+## Configuration available
+
+Currently, there is 2 configurable behaviors:
+
+### Gitlab hosts
+
+Unlike Github or Bitbucket that have fixed domains, Gitlab instances are
+self-hosted so there is no way to automatically detects that a domain
+correspond to a Gitlab instance.
+
+The `gitlab-hosts` option can be setup to inform the plugin about the hosts it
+should consider as Gitlab instance.
+
+```json
+{
+    "extra": {
+        "composer-changelogs": {
+            "gitlab-hosts": [
+                "gitlab.my-company.org"
+            ],
+        }
+    }
+}
+```
+
+### Autocommit feature
+
+See [the full documentation of this feature](autocommit.md).
+

--- a/src/ChangelogsPlugin.php
+++ b/src/ChangelogsPlugin.php
@@ -49,11 +49,12 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
     {
         $this->composer = $composer;
         $this->io = $io;
-        $this->outputter = Factory::createOutputter();
         $this->configLocator = new ConfigLocator($composer);
 
         $this->setupConfig();
         $this->autoloadNeededClasses();
+
+        $this->outputter = Factory::createOutputter($this->config->getGitlabHosts());
     }
 
     /**

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -22,16 +22,21 @@ class Config
     /** @var string */
     private $commitMessage;
 
+    /** @var string[] */
+    private $gitlabHosts;
+
     /**
      * @param string      $commitAuto
      * @param string|null $commitBinFile
      * @param string      $commitMessage
+     * @param string[]    $gitlabHosts
      */
-    public function __construct($commitAuto, $commitBinFile, $commitMessage)
+    public function __construct($commitAuto, $commitBinFile, $commitMessage, array $gitlabHosts)
     {
         $this->commitAuto = $commitAuto;
         $this->commitBinFile = $commitBinFile;
         $this->commitMessage = $commitMessage;
+        $this->gitlabHosts = $gitlabHosts;
     }
 
     /**
@@ -56,5 +61,13 @@ class Config
     public function getCommitMessage()
     {
         return $this->commitMessage;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getGitlabHosts()
+    {
+        return $this->gitlabHosts;
     }
 }

--- a/src/Config/ConfigBuilder.php
+++ b/src/Config/ConfigBuilder.php
@@ -37,6 +37,7 @@ class ConfigBuilder
         $commitAuto = 'never';
         $commitBinFile = null;
         $commitMessage = 'Update dependencies';
+        $gitlabHosts = [];
 
         if (array_key_exists('commit-auto', $extra)) {
             if (in_array($extra['commit-auto'], self::$validCommitAutoValues, true)) {
@@ -84,7 +85,15 @@ class ConfigBuilder
             }
         }
 
-        return new Config($commitAuto, $commitBinFile, $commitMessage);
+        if (array_key_exists('gitlab-hosts', $extra)) {
+            if (!is_array($extra['gitlab-hosts'])) {
+                $this->warnings[] = '"gitlab-hosts" is specified but should be an array. Ignoring.';
+            } else {
+                $gitlabHosts = (array) $extra['gitlab-hosts'];
+            }
+        }
+
+        return new Config($commitAuto, $commitBinFile, $commitMessage, $gitlabHosts);
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -29,25 +29,35 @@ class Factory
     }
 
     /**
+     * @param string[] $gitlabHosts
+     *
      * @return UrlGenerator[]
      */
-    public static function createUrlGenerators()
+    public static function createUrlGenerators(array $gitlabHosts = [])
     {
-        return [
+        $hosts = [
             new \Pyrech\ComposerChangelogs\UrlGenerator\GithubUrlGenerator(),
             new \Pyrech\ComposerChangelogs\UrlGenerator\BitbucketUrlGenerator(),
             new \Pyrech\ComposerChangelogs\UrlGenerator\WordPressUrlGenerator(),
         ];
+
+        foreach ($gitlabHosts as $gitlabHost) {
+            $hosts[] = new \Pyrech\ComposerChangelogs\UrlGenerator\GitlabUrlGenerator($gitlabHost);
+        }
+
+        return $hosts;
     }
 
     /**
+     * @param string[] $gitlabHosts
+     *
      * @return Outputter
      */
-    public static function createOutputter()
+    public static function createOutputter(array $gitlabHosts = [])
     {
         return new Outputter(
             self::createOperationHandlers(),
-            self::createUrlGenerators()
+            self::createUrlGenerators($gitlabHosts)
         );
     }
 }

--- a/src/UrlGenerator/GitlabUrlGenerator.php
+++ b/src/UrlGenerator/GitlabUrlGenerator.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the composer-changelogs project.
+ *
+ * (c) Loïck Piera <pyrech@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pyrech\ComposerChangelogs\UrlGenerator;
+
+use Pyrech\ComposerChangelogs\Version;
+
+class GitlabUrlGenerator extends AbstractUrlGenerator
+{
+    /** @var string */
+    private $host;
+
+    /**
+     * @param string $host
+     */
+    public function __construct($host)
+    {
+        $this->host = $host;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDomain()
+    {
+        return $this->host;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateCompareUrl($sourceUrlFrom, Version $versionFrom, $sourceUrlTo, Version $versionTo)
+    {
+        // Check if both urls come from the supported domain
+        // It avoids problems when one url is from another domain or is local
+        if (!$this->supports($sourceUrlFrom) || !$this->supports($sourceUrlTo)) {
+            return false;
+        }
+
+        $sourceUrlFrom = $this->generateBaseUrl($sourceUrlFrom);
+        $sourceUrlTo = $this->generateBaseUrl($sourceUrlTo);
+
+        if ($sourceUrlFrom !== $sourceUrlTo) {
+            // Comparison across forks is not supported
+            return false;
+        }
+
+        return sprintf(
+            '%s/compare/%s...%s',
+            $sourceUrlTo,
+            $this->getCompareVersion($versionFrom),
+            $this->getCompareVersion($versionTo)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateReleaseUrl($sourceUrl, Version $version)
+    {
+        if ($version->isDev()) {
+            return false;
+        }
+
+        return sprintf(
+            '%s/tags/%s',
+            $this->generateBaseUrl($sourceUrl),
+            $version->getPretty()
+        );
+    }
+}

--- a/tests/Config/ConfigBuilderTest.php
+++ b/tests/Config/ConfigBuilderTest.php
@@ -38,6 +38,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
+        static::assertEmpty($config->getGitlabHosts());
 
         static::assertCount(0, $this->SUT->getWarnings());
     }
@@ -53,6 +54,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
+        static::assertEmpty($config->getGitlabHosts());
 
         static::assertCount(1, $this->SUT->getWarnings());
         static::assertContains('Invalid value "foo" for option "commit-auto"', $this->SUT->getWarnings()[0]);
@@ -70,6 +72,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
+        static::assertEmpty($config->getGitlabHosts());
 
         static::assertCount(1, $this->SUT->getWarnings());
         static::assertContains('"commit-bin-file" is specified but "commit-auto" option is set to "never". Ignoring.', $this->SUT->getWarnings()[0]);
@@ -87,6 +90,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
         static::assertSame('always', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
+        static::assertEmpty($config->getGitlabHosts());
 
         static::assertCount(1, $this->SUT->getWarnings());
         static::assertContains('The file pointed by the option "commit-bin-file" was not found. Ignoring.', $this->SUT->getWarnings()[0]);
@@ -103,9 +107,27 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
         static::assertSame('ask', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
+        static::assertEmpty($config->getGitlabHosts());
 
         static::assertCount(1, $this->SUT->getWarnings());
         static::assertContains('"commit-auto" is set to "ask" but "commit-bin-file" was not specified.', $this->SUT->getWarnings()[0]);
+    }
+
+    public function test_it_warns_when_gitlab_hosts_is_not_an_array()
+    {
+        $extra = [
+            'gitlab-hosts' => 'gitlab.company1.com',
+        ];
+
+        $config = $this->SUT->build($extra, __DIR__);
+
+        static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
+        static::assertSame('never', $config->getCommitAuto());
+        static::assertNull($config->getCommitBinFile());
+        static::assertEmpty($config->getGitlabHosts());
+
+        static::assertCount(1, $this->SUT->getWarnings());
+        static::assertContains('"gitlab-hosts" is specified but should be an array. Ignoring.', $this->SUT->getWarnings()[0]);
     }
 
     public function test_it_accepts_valid_setup()
@@ -113,6 +135,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         $extra = [
             'commit-auto' => 'ask',
             'commit-bin-file' => self::COMMIT_BIN_FILE,
+            'gitlab-hosts' => ['gitlab.company1.com', 'gitlab.company2.com'],
         ];
 
         $config = $this->SUT->build($extra, __DIR__);
@@ -120,6 +143,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
         static::assertSame('ask', $config->getCommitAuto());
         static::assertSame($this->absoluteCommitBinFile, $config->getCommitBinFile());
+        static::assertCount(2, $config->getGitlabHosts());
 
         static::assertCount(0, $this->SUT->getWarnings());
     }

--- a/tests/UrlGenerator/GitlabUrlGeneratorTest.php
+++ b/tests/UrlGenerator/GitlabUrlGeneratorTest.php
@@ -1,0 +1,209 @@
+<?php
+
+/*
+ * This file is part of the composer-changelogs project.
+ *
+ * (c) Loïck Piera <pyrech@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pyrech\ComposerChangelogs\tests\UrlGenerator;
+
+use Pyrech\ComposerChangelogs\UrlGenerator\GitlabUrlGenerator;
+use Pyrech\ComposerChangelogs\Version;
+
+class GitlabUrlGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var GitlabUrlGenerator */
+    private $SUT;
+
+    protected function setUp()
+    {
+        $this->SUT = new GitlabUrlGenerator('gitlab.company.org');
+    }
+
+    public function test_it_supports_gitlab_urls()
+    {
+        $this->assertTrue($this->SUT->supports('https://gitlab.company.org/phpunit/phpunit-mock-objects.git'));
+        $this->assertTrue($this->SUT->supports('https://gitlab.company.org/symfony/console'));
+        $this->assertTrue($this->SUT->supports('git@gitlab.company.org:private/repo.git'));
+    }
+
+    public function test_it_does_not_support_non_gitlab_urls()
+    {
+        $this->assertFalse($this->SUT->supports('https://company.org/about-us'));
+        $this->assertFalse($this->SUT->supports('https://bitbucket.org/rogoOOS/rog'));
+    }
+
+    public function test_it_generates_compare_urls_with_or_without_git_extension_in_source_url()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertSame(
+            'https://gitlab.company.org/acme/repo/compare/v1.0.0...v1.0.1',
+            $this->SUT->generateCompareUrl(
+                'https://gitlab.company.org/acme/repo',
+                $versionFrom,
+                'https://gitlab.company.org/acme/repo',
+                $versionTo
+            )
+        );
+
+        $this->assertSame(
+            'https://gitlab.company.org/acme/repo/compare/v1.0.0...v1.0.1',
+            $this->SUT->generateCompareUrl(
+                'https://gitlab.company.org/acme/repo.git',
+                $versionFrom,
+                'https://gitlab.company.org/acme/repo.git',
+                $versionTo
+            )
+        );
+    }
+
+    public function test_it_generates_compare_urls_with_dev_versions()
+    {
+        $versionFrom = new Version('v.1.0.9999999.9999999-dev', 'dev-master', 'dev-master 1234abc');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertSame(
+            'https://gitlab.company.org/acme/repo/compare/1234abc...v1.0.1',
+            $this->SUT->generateCompareUrl(
+                'https://gitlab.company.org/acme/repo.git',
+                $versionFrom,
+                'https://gitlab.company.org/acme/repo.git',
+                $versionTo
+            )
+        );
+
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('9999999-dev', 'dev-master', 'dev-master 6789def');
+
+        $this->assertSame(
+            'https://gitlab.company.org/acme/repo/compare/v1.0.0...6789def',
+            $this->SUT->generateCompareUrl(
+                'https://gitlab.company.org/acme/repo.git',
+                $versionFrom,
+                'https://gitlab.company.org/acme/repo.git',
+                $versionTo
+            )
+        );
+
+        $versionFrom = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+        $versionTo = new Version('dev-fix/issue', 'dev-fix/issue', 'dev-fix/issue 1234abc');
+
+        $this->assertSame(
+            'https://gitlab.company.org/acme/repo/compare/v1.0.1...1234abc',
+            $this->SUT->generateCompareUrl(
+                'https://gitlab.company.org/acme/repo.git',
+                $versionFrom,
+                'https://gitlab.company.org/acme/repo.git',
+                $versionTo
+            )
+        );
+    }
+
+    public function test_it_does_not_generate_compare_urls_across_forks()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertFalse(
+            $this->SUT->generateCompareUrl(
+                'https://gitlab.company.org/acme1/repo',
+                $versionFrom,
+                'https://gitlab.company.org/acme2/repo',
+                $versionTo
+            )
+        );
+    }
+
+    public function test_it_does_not_generate_compare_urls_for_unsupported_url()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertFalse(
+            $this->SUT->generateCompareUrl(
+                '/home/toto/work/my-package',
+                $versionFrom,
+                'https://gitlab.company.org/acme2/repo',
+                $versionTo
+            )
+        );
+
+        $this->assertFalse(
+            $this->SUT->generateCompareUrl(
+                'https://gitlab.company.org/acme1/repo',
+                $versionFrom,
+                '/home/toto/work/my-package',
+                $versionTo
+            )
+        );
+    }
+
+    public function test_it_generates_compare_urls_with_ssh_source_url()
+    {
+        $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
+        $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
+
+        $this->assertSame(
+            'https://gitlab.company.org/acme/repo/compare/v1.0.0...v1.0.1',
+            $this->SUT->generateCompareUrl(
+                'git@gitlab.company.org:acme/repo.git',
+                $versionFrom,
+                'git@gitlab.company.org:acme/repo.git',
+                $versionTo
+            )
+        );
+    }
+
+    public function test_it_does_not_generate_release_urls_for_dev_version()
+    {
+        $this->assertFalse(
+            $this->SUT->generateReleaseUrl(
+                'https://gitlab.company.org/acme/repo',
+                new Version('9999999-dev', 'dev-master', 'dev-master 1234abc')
+            )
+        );
+
+        $this->assertFalse(
+            $this->SUT->generateReleaseUrl(
+                'https://gitlab.company.org/acme/repo',
+                new Version('dev-fix/issue', 'dev-fix/issue', 'dev-fix/issue 1234abc')
+            )
+        );
+    }
+
+    public function test_it_generates_release_urls()
+    {
+        $this->assertSame(
+            'https://gitlab.company.org/acme/repo/tags/v1.0.1',
+            $this->SUT->generateReleaseUrl(
+                'https://gitlab.company.org/acme/repo',
+                new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1')
+            )
+        );
+
+        $this->assertSame(
+            'https://gitlab.company.org/acme/repo/tags/v1.0.1',
+            $this->SUT->generateReleaseUrl(
+                'https://gitlab.company.org/acme/repo.git',
+                new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1')
+            )
+        );
+    }
+
+    public function test_it_generates_release_url_with_ssh_source_url()
+    {
+        $this->assertSame(
+            'https://gitlab.company.org/acme/repo/tags/v1.0.1',
+            $this->SUT->generateReleaseUrl(
+                'git@gitlab.company.org:acme/repo.git',
+                new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1')
+            )
+        );
+    }
+}


### PR DESCRIPTION
Fixes #34

Gitlab instances can now be specified through the `gitlab-hosts` config parameter. See the [documentation](https://github.com/pyrech/composer-changelogs/blob/feature/support-gitlab/doc/configuration.md#gitlab-hosts) to see how to setup it.