### PR TITLE
Lower PHP requirements from 5.4 to 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ cache:
 matrix:
     include:
         - php: hhvm
-        - php: 5.4
+        - php: 5.3
           env: check_cs=true
+        - php: 5.4
         - php: 5.5
         - php: 5.6
           env: deps=low coverage=true

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.3.0",
         "composer-plugin-api": "^1.0|^1.1"
     },
     "require-dev": {

--- a/src/ChangelogsPlugin.php
+++ b/src/ChangelogsPlugin.php
@@ -62,20 +62,20 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return [
-            PackageEvents::POST_PACKAGE_UPDATE => [
-                ['postPackageOperation'],
-            ],
-            PackageEvents::POST_PACKAGE_INSTALL => [
-                ['postPackageOperation'],
-            ],
-            PackageEvents::POST_PACKAGE_UNINSTALL => [
-                ['postPackageOperation'],
-            ],
-            ScriptEvents::POST_UPDATE_CMD => [
-                ['postUpdate'],
-            ],
-        ];
+        return array(
+            PackageEvents::POST_PACKAGE_UPDATE => array(
+                array('postPackageOperation'),
+            ),
+            PackageEvents::POST_PACKAGE_INSTALL => array(
+                array('postPackageOperation'),
+            ),
+            PackageEvents::POST_PACKAGE_UNINSTALL => array(
+                array('postPackageOperation'),
+            ),
+            ScriptEvents::POST_UPDATE_CMD => array(
+                array('postUpdate'),
+            ),
+        );
     }
 
     /**
@@ -111,9 +111,9 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
      */
     private function autoloadNeededClasses()
     {
-        $classes = [
+        $classes = array(
             'Pyrech\ComposerChangelogs\Version',
-        ];
+        );
 
         foreach ($classes as $class) {
             // Force the class to be autoloaded

--- a/src/Config/ConfigBuilder.php
+++ b/src/Config/ConfigBuilder.php
@@ -15,14 +15,14 @@ use Pyrech\ComposerChangelogs\Util\FileSystemHelper;
 
 class ConfigBuilder
 {
-    private static $validCommitAutoValues = [
+    private static $validCommitAutoValues = array(
         'never',
         'ask',
         'always',
-    ];
+    );
 
     /** @var string[] */
-    private $warnings = [];
+    private $warnings = array();
 
     /**
      * @param array  $extra
@@ -37,7 +37,7 @@ class ConfigBuilder
         $commitAuto = 'never';
         $commitBinFile = null;
         $commitMessage = 'Update dependencies';
-        $gitlabHosts = [];
+        $gitlabHosts = array();
 
         if (array_key_exists('commit-auto', $extra)) {
             if (in_array($extra['commit-auto'], self::$validCommitAutoValues, true)) {
@@ -106,7 +106,7 @@ class ConfigBuilder
 
     private function reset()
     {
-        $this->warnings = [];
+        $this->warnings = array();
     }
 
     /**

--- a/src/Config/ConfigLocator.php
+++ b/src/Config/ConfigLocator.php
@@ -19,7 +19,7 @@ class ConfigLocator
     private $composer;
 
     /** @var array */
-    public $cache = [];
+    public $cache = array();
 
     /**
      * @param Composer $composer
@@ -74,11 +74,11 @@ class ConfigLocator
             return true;
         }
 
-        $this->cache[$key] = [
+        $this->cache[$key] = array(
             'found' => false,
-            'config' => [],
+            'config' => array(),
             'path' => null,
-        ];
+        );
 
         return false;
     }
@@ -104,11 +104,11 @@ class ConfigLocator
         $localComposerExtra = $this->composer->getPackage()->getExtra();
 
         if (array_key_exists($key, $localComposerExtra)) {
-            $this->cache[$key] = [
+            $this->cache[$key] = array(
                 'found' => true,
                 'config' => $localComposerExtra[$key],
                 'path' => $path,
-            ];
+            );
 
             return true;
         }
@@ -133,11 +133,11 @@ class ConfigLocator
             $globalComposerJson = json_decode(file_get_contents($globalComposerJsonFile), true);
 
             if (array_key_exists('extra', $globalComposerJson) && array_key_exists($key, $globalComposerJson['extra'])) {
-                $this->cache[$key] = [
+                $this->cache[$key] = array(
                     'found' => true,
                     'config' => $globalComposerJson['extra'][$key],
                     'path' => $path,
-                ];
+                );
 
                 return true;
             }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -21,11 +21,11 @@ class Factory
      */
     public static function createOperationHandlers()
     {
-        return [
+        return array(
             new \Pyrech\ComposerChangelogs\OperationHandler\InstallHandler(),
             new \Pyrech\ComposerChangelogs\OperationHandler\UpdateHandler(),
             new \Pyrech\ComposerChangelogs\OperationHandler\UninstallHandler(),
-        ];
+        );
     }
 
     /**
@@ -33,13 +33,13 @@ class Factory
      *
      * @return UrlGenerator[]
      */
-    public static function createUrlGenerators(array $gitlabHosts = [])
+    public static function createUrlGenerators(array $gitlabHosts = array())
     {
-        $hosts = [
+        $hosts = array(
             new \Pyrech\ComposerChangelogs\UrlGenerator\GithubUrlGenerator(),
             new \Pyrech\ComposerChangelogs\UrlGenerator\BitbucketUrlGenerator(),
             new \Pyrech\ComposerChangelogs\UrlGenerator\WordPressUrlGenerator(),
-        ];
+        );
 
         foreach ($gitlabHosts as $gitlabHost) {
             $hosts[] = new \Pyrech\ComposerChangelogs\UrlGenerator\GitlabUrlGenerator($gitlabHost);
@@ -53,7 +53,7 @@ class Factory
      *
      * @return Outputter
      */
-    public static function createOutputter(array $gitlabHosts = [])
+    public static function createOutputter(array $gitlabHosts = array())
     {
         return new Outputter(
             self::createOperationHandlers(),

--- a/src/OperationHandler/InstallHandler.php
+++ b/src/OperationHandler/InstallHandler.php
@@ -48,7 +48,7 @@ class InstallHandler implements OperationHandler
             throw new \LogicException('Operation should be an instance of InstallOperation');
         }
 
-        $output = [];
+        $output = array();
 
         $package = $operation->getPackage();
         $version = new Version(

--- a/src/OperationHandler/UninstallHandler.php
+++ b/src/OperationHandler/UninstallHandler.php
@@ -48,7 +48,7 @@ class UninstallHandler implements OperationHandler
             throw new \LogicException('Operation should be an instance of UninstallOperation');
         }
 
-        $output = [];
+        $output = array();
 
         $package = $operation->getPackage();
         $version = new Version(

--- a/src/OperationHandler/UpdateHandler.php
+++ b/src/OperationHandler/UpdateHandler.php
@@ -49,7 +49,7 @@ class UpdateHandler implements OperationHandler
             throw new \LogicException('Operation should be an instance of UpdateOperation');
         }
 
-        $output = [];
+        $output = array();
 
         $initialPackage = $operation->getInitialPackage();
         $targetPackage = $operation->getTargetPackage();

--- a/src/Outputter.php
+++ b/src/Outputter.php
@@ -34,7 +34,7 @@ class Outputter
     {
         $this->urlGenerators = $urlGenerators;
         $this->operationHandlers = $operationHandlers;
-        $this->operations = [];
+        $this->operations = array();
     }
 
     /**
@@ -58,7 +58,7 @@ class Outputter
      */
     public function getOutput()
     {
-        $output = [];
+        $output = array();
 
         if ($this->isEmpty()) {
             $output[] = '<fg=green>No changelogs summary</fg=green>';

--- a/src/UrlGenerator/GitBasedUrlGenerator.php
+++ b/src/UrlGenerator/GitBasedUrlGenerator.php
@@ -100,10 +100,10 @@ abstract class GitBasedUrlGenerator implements UrlGenerator
             );
         }
 
-        return [
+        return array(
             'user' => $matches['user'],
             'repository' => $matches['repository'],
-        ];
+        );
     }
 
     /**

--- a/tests/ChangelogsPluginTest.php
+++ b/tests/ChangelogsPluginTest.php
@@ -51,11 +51,11 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
     {
         $this->tempDir = __DIR__ . '/temp';
         $this->config = new Config(false, realpath(__DIR__ . '/fixtures/local'));
-        $this->config->merge([
-            'config' => [
+        $this->config->merge(array(
+            'config' => array(
                 'home' => __DIR__,
-            ],
-        ]);
+            ),
+        ));
 
         $this->io = new BufferIO();
 
@@ -98,7 +98,7 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
 
         $this->addComposerPlugin($plugin);
 
-        $this->assertSame([$plugin], $this->composer->getPluginManager()->getPlugins());
+        $this->assertSame(array($plugin), $this->composer->getPluginManager()->getPlugins());
         $this->assertAttributeInstanceOf('Composer\IO\IOInterface', 'io', $plugin);
         $this->assertAttributeInstanceOf('Pyrech\ComposerChangelogs\Outputter', 'outputter', $plugin);
     }
@@ -114,9 +114,9 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
             false,
             new DefaultPolicy(false, false),
             new Pool(),
-            new CompositeRepository([]),
+            new CompositeRepository(array()),
             new Request(new Pool()),
-            [$operation],
+            array($operation),
             $operation
         );
 
@@ -149,9 +149,9 @@ OUTPUT;
             false,
             new DefaultPolicy(false, false),
             new Pool(),
-            new CompositeRepository([]),
+            new CompositeRepository(array()),
             new Request(new Pool()),
-            [$operation],
+            array($operation),
             $operation
         );
         $plugin->postPackageOperation($packageEvent);
@@ -174,11 +174,11 @@ OUTPUT;
 
     public function test_it_commits_with_always_option()
     {
-        $this->config->merge([
-            'config' => [
+        $this->config->merge(array(
+            'config' => array(
                 'home' => realpath(__DIR__ . '/fixtures/home'),
-            ],
-        ]);
+            ),
+        ));
 
         $plugin = new ChangelogsPlugin();
         $plugin->activate($this->composer, $this->io);
@@ -192,9 +192,9 @@ OUTPUT;
             false,
             new DefaultPolicy(false, false),
             new Pool(),
-            new CompositeRepository([]),
+            new CompositeRepository(array()),
             new Request(new Pool()),
-            [$operation],
+            array($operation),
             $operation
         );
         $plugin->postPackageOperation($packageEvent);
@@ -207,11 +207,11 @@ OUTPUT;
 
     public function test_it_commits_with_default_commit_message()
     {
-        $this->config->merge([
-            'config' => [
+        $this->config->merge(array(
+            'config' => array(
                 'home' => realpath(__DIR__ . '/fixtures/home'),
-            ],
-        ]);
+            ),
+        ));
 
         $plugin = new ChangelogsPlugin();
         $plugin->activate($this->composer, $this->io);
@@ -225,9 +225,9 @@ OUTPUT;
             false,
             new DefaultPolicy(false, false),
             new Pool(),
-            new CompositeRepository([]),
+            new CompositeRepository(array()),
             new Request(new Pool()),
-            [$operation],
+            array($operation),
             $operation
         );
         $plugin->postPackageOperation($packageEvent);
@@ -242,11 +242,11 @@ OUTPUT;
 
     public function test_it_commits_with_custom_commit_message()
     {
-        $this->config->merge([
-            'config' => [
+        $this->config->merge(array(
+            'config' => array(
                 'home' => realpath(__DIR__ . '/fixtures/home-commit-message'),
-            ],
-        ]);
+            ),
+        ));
 
         $plugin = new ChangelogsPlugin();
         $plugin->activate($this->composer, $this->io);
@@ -260,9 +260,9 @@ OUTPUT;
             false,
             new DefaultPolicy(false, false),
             new Pool(),
-            new CompositeRepository([]),
+            new CompositeRepository(array()),
             new Request(new Pool()),
-            [$operation],
+            array($operation),
             $operation
         );
         $plugin->postPackageOperation($packageEvent);

--- a/tests/Config/ConfigBuilderTest.php
+++ b/tests/Config/ConfigBuilderTest.php
@@ -56,8 +56,9 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
 
-        static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('Invalid value "foo" for option "commit-auto"', $this->SUT->getWarnings()[0]);
+        $warnings = $this->SUT->getWarnings();
+        static::assertCount(1, $warnings);
+        static::assertContains('Invalid value "foo" for option "commit-auto"', $warnings[0]);
     }
 
     public function test_it_warns_when_specifying_commit_bin_file_and_never_auto_commit()
@@ -74,8 +75,9 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
 
-        static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('"commit-bin-file" is specified but "commit-auto" option is set to "never". Ignoring.', $this->SUT->getWarnings()[0]);
+        $warnings = $this->SUT->getWarnings();
+        static::assertCount(1, $warnings);
+        static::assertContains('"commit-bin-file" is specified but "commit-auto" option is set to "never". Ignoring.', $warnings[0]);
     }
 
     public function test_it_warns_when_specified_commit_bin_file_was_not_found()
@@ -92,8 +94,9 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
 
-        static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('The file pointed by the option "commit-bin-file" was not found. Ignoring.', $this->SUT->getWarnings()[0]);
+        $warnings = $this->SUT->getWarnings();
+        static::assertCount(1, $warnings);
+        static::assertContains('The file pointed by the option "commit-bin-file" was not found. Ignoring.', $warnings[0]);
     }
 
     public function test_it_warns_when_commit_bin_file_should_have_been_specified()
@@ -109,8 +112,9 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
 
-        static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('"commit-auto" is set to "ask" but "commit-bin-file" was not specified.', $this->SUT->getWarnings()[0]);
+        $warnings = $this->SUT->getWarnings();
+        static::assertCount(1, $warnings);
+        static::assertContains('"commit-auto" is set to "ask" but "commit-bin-file" was not specified.', $warnings[0]);
     }
 
     public function test_it_warns_when_gitlab_hosts_is_not_an_array()
@@ -126,8 +130,9 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
 
-        static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('"gitlab-hosts" is specified but should be an array. Ignoring.', $this->SUT->getWarnings()[0]);
+        $warnings = $this->SUT->getWarnings();
+        static::assertCount(1, $warnings);
+        static::assertContains('"gitlab-hosts" is specified but should be an array. Ignoring.', $warnings[0]);
     }
 
     public function test_it_accepts_valid_setup()

--- a/tests/Config/ConfigBuilderTest.php
+++ b/tests/Config/ConfigBuilderTest.php
@@ -31,7 +31,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_has_a_default_setup()
     {
-        $extra = [];
+        $extra = array();
 
         $config = $this->SUT->build($extra, __DIR__);
 
@@ -45,9 +45,9 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_warns_when_commit_auto_option_is_invalid()
     {
-        $extra = [
+        $extra = array(
             'commit-auto' => 'foo',
-        ];
+        );
 
         $config = $this->SUT->build($extra, __DIR__);
 
@@ -62,10 +62,10 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_warns_when_specifying_commit_bin_file_and_never_auto_commit()
     {
-        $extra = [
+        $extra = array(
             'commit-auto' => 'never',
             'commit-bin-file' => self::COMMIT_BIN_FILE,
-        ];
+        );
 
         $config = $this->SUT->build($extra, __DIR__);
 
@@ -80,10 +80,10 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_warns_when_specified_commit_bin_file_was_not_found()
     {
-        $extra = [
+        $extra = array(
             'commit-auto' => 'always',
             'commit-bin-file' => '/tmp/toto',
-        ];
+        );
 
         $config = $this->SUT->build($extra, __DIR__);
 
@@ -98,9 +98,9 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_warns_when_commit_bin_file_should_have_been_specified()
     {
-        $extra = [
+        $extra = array(
             'commit-auto' => 'ask',
-        ];
+        );
 
         $config = $this->SUT->build($extra, __DIR__);
 
@@ -115,9 +115,9 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_warns_when_gitlab_hosts_is_not_an_array()
     {
-        $extra = [
+        $extra = array(
             'gitlab-hosts' => 'gitlab.company1.com',
-        ];
+        );
 
         $config = $this->SUT->build($extra, __DIR__);
 
@@ -132,11 +132,11 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_accepts_valid_setup()
     {
-        $extra = [
+        $extra = array(
             'commit-auto' => 'ask',
             'commit-bin-file' => self::COMMIT_BIN_FILE,
-            'gitlab-hosts' => ['gitlab.company1.com', 'gitlab.company2.com'],
-        ];
+            'gitlab-hosts' => array('gitlab.company1.com', 'gitlab.company2.com'),
+        );
 
         $config = $this->SUT->build($extra, __DIR__);
 

--- a/tests/Config/ConfigLocatorTest.php
+++ b/tests/Config/ConfigLocatorTest.php
@@ -42,18 +42,18 @@ class ConfigLocatorTest extends \PHPUnit_Framework_TestCase
         $this->globalConfigPath = realpath(__DIR__ . '/../fixtures/home');
 
         $this->config = new Config(false, $this->localConfigPath);
-        $this->config->merge([
-            'config' => [
+        $this->config->merge(array(
+            'config' => array(
                 'home' => $this->globalConfigPath,
-            ],
-        ]);
+            ),
+        ));
 
         $package = new RootPackage('my/project', '1.0.0', '1.0.0');
-        $package->setExtra([
-            'my-local-config' => [
+        $package->setExtra(array(
+            'my-local-config' => array(
                 'foo' => 'bar',
-            ],
-        ]);
+            ),
+        ));
 
         $this->composer = new Composer();
         $this->composer->setConfig($this->config);
@@ -69,7 +69,7 @@ class ConfigLocatorTest extends \PHPUnit_Framework_TestCase
         static::assertTrue($this->SUT->locate($key));
 
         static::assertSame($this->localConfigPath, $this->SUT->getPath($key));
-        static::assertSame(['foo' => 'bar'], $this->SUT->getConfig($key));
+        static::assertSame(array('foo' => 'bar'), $this->SUT->getConfig($key));
     }
 
     public function test_it_locates_global_config()
@@ -79,7 +79,7 @@ class ConfigLocatorTest extends \PHPUnit_Framework_TestCase
         static::assertTrue($this->SUT->locate($key));
 
         static::assertSame($this->globalConfigPath, $this->SUT->getPath($key));
-        static::assertSame(['bar' => 'foo'], $this->SUT->getConfig($key));
+        static::assertSame(array('bar' => 'foo'), $this->SUT->getConfig($key));
     }
 
     public function test_it_does_not_locate_non_existing_config()
@@ -89,6 +89,6 @@ class ConfigLocatorTest extends \PHPUnit_Framework_TestCase
         static::assertFalse($this->SUT->locate($key));
 
         static::assertNull($this->SUT->getPath($key));
-        static::assertSame([], $this->SUT->getConfig($key));
+        static::assertSame(array(), $this->SUT->getConfig($key));
     }
 }

--- a/tests/OperationHandler/InstallHandlerTest.php
+++ b/tests/OperationHandler/InstallHandlerTest.php
@@ -70,9 +70,9 @@ class InstallHandlerTest extends \PHPUnit_Framework_TestCase
 
         $operation = new InstallOperation($package);
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project</fg=green> installed in version <fg=yellow>v1.0.0</fg=yellow>',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -92,10 +92,10 @@ class InstallHandlerTest extends \PHPUnit_Framework_TestCase
             'https://example.com/acme/my-project/release/v1.0.1'
         );
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project</fg=green> installed in version <fg=yellow>v1.0.0</fg=yellow>',
             '   Release notes: https://example.com/acme/my-project/release/v1.0.1',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -115,9 +115,9 @@ class InstallHandlerTest extends \PHPUnit_Framework_TestCase
             false
         );
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project</fg=green> installed in version <fg=yellow>v1.0.0</fg=yellow>',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -137,10 +137,10 @@ class InstallHandlerTest extends \PHPUnit_Framework_TestCase
             'https://example.com/acme/my-project/release/v1.0.1'
         );
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project</fg=green> installed in version <fg=yellow>v1.0.0</fg=yellow>',
             '   Release notes: https://example.com/acme/my-project/release/v1.0.1',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,

--- a/tests/OperationHandler/UninstallHandlerTest.php
+++ b/tests/OperationHandler/UninstallHandlerTest.php
@@ -70,9 +70,9 @@ class UninstallHandlerTest extends \PHPUnit_Framework_TestCase
 
         $operation = new UninstallOperation($package);
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project</fg=green> removed (installed version was <fg=yellow>v1.0.0</fg=yellow>)',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -92,9 +92,9 @@ class UninstallHandlerTest extends \PHPUnit_Framework_TestCase
             'https://example.com/acme/my-project/release/v1.0.1'
         );
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project</fg=green> removed (installed version was <fg=yellow>v1.0.0</fg=yellow>)',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -114,9 +114,9 @@ class UninstallHandlerTest extends \PHPUnit_Framework_TestCase
             false
         );
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project</fg=green> removed (installed version was <fg=yellow>v1.0.0</fg=yellow>)',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -136,9 +136,9 @@ class UninstallHandlerTest extends \PHPUnit_Framework_TestCase
             'https://example.com/acme/my-project/release/v1.0.1'
         );
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project</fg=green> removed (installed version was <fg=yellow>v1.0.0</fg=yellow>)',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,

--- a/tests/OperationHandler/UpdateHandlerTest.php
+++ b/tests/OperationHandler/UpdateHandlerTest.php
@@ -77,9 +77,9 @@ class UpdateHandlerTest extends \PHPUnit_Framework_TestCase
 
         $operation = new UpdateOperation($package1, $package2);
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project1</fg=green> updated from <fg=yellow>v1.0.0</fg=yellow> to <fg=yellow>v1.0.1</fg=yellow>',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -100,10 +100,10 @@ class UpdateHandlerTest extends \PHPUnit_Framework_TestCase
             'https://example.com/acme/my-project/release/v1.0.1'
         );
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project1</fg=green> updated from <fg=yellow>v1.0.0</fg=yellow> to <fg=yellow>v1.0.1</fg=yellow>',
             '   Release notes: https://example.com/acme/my-project/release/v1.0.1',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -124,10 +124,10 @@ class UpdateHandlerTest extends \PHPUnit_Framework_TestCase
             false
         );
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project1</fg=green> updated from <fg=yellow>v1.0.0</fg=yellow> to <fg=yellow>v1.0.1</fg=yellow>',
             '   See changes: https://example.com/acme/my-project/compare/v1.0.0/v1.0.1',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -148,11 +148,11 @@ class UpdateHandlerTest extends \PHPUnit_Framework_TestCase
             'https://example.com/acme/my-project/release/v1.0.1'
         );
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project1</fg=green> updated from <fg=yellow>v1.0.0</fg=yellow> to <fg=yellow>v1.0.1</fg=yellow>',
             '   See changes: https://example.com/acme/my-project/compare/v1.0.0/v1.0.1',
             '   Release notes: https://example.com/acme/my-project/release/v1.0.1',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -176,9 +176,9 @@ class UpdateHandlerTest extends \PHPUnit_Framework_TestCase
 
         $operationUpdate = new UpdateOperation($package1, $package2);
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project1</fg=green> updated from <fg=yellow>v1.0.0</fg=yellow> to <fg=yellow>v1.0.1</fg=yellow>',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,
@@ -187,9 +187,9 @@ class UpdateHandlerTest extends \PHPUnit_Framework_TestCase
 
         $operationDowngrade = new UpdateOperation($package2, $package1);
 
-        $expectedOutput = [
+        $expectedOutput = array(
             ' - <fg=green>acme/my-project2</fg=green> downgraded from <fg=yellow>v1.0.1</fg=yellow> to <fg=yellow>v1.0.0</fg=yellow>',
-        ];
+        );
 
         $this->assertSame(
             $expectedOutput,

--- a/tests/OutputterTest.php
+++ b/tests/OutputterTest.php
@@ -31,46 +31,46 @@ class OutputterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->operationHandlers = [
+        $this->operationHandlers = array(
             new FakeHandler(false, 'http://domain1', 'Output handler 1'),
             new FakeHandler(true, 'http://domain2', 'Output handler 2'),
             new FakeHandler(true, 'http://domain3', 'Output handler 3'),
-        ];
+        );
 
-        $this->urlGenerators = [
+        $this->urlGenerators = array(
             new FakeUrlGenerator(false, '/compare-url1', '/release-url1'),
             new FakeUrlGenerator(true, '/compare-url2', '/release-url2'),
             new FakeUrlGenerator(true, '/compare-url3', '/release-url3'),
-        ];
+        );
 
         $this->SUT = new Outputter($this->operationHandlers, $this->urlGenerators);
     }
 
     public function test_it_adds_operation()
     {
-        $this->assertAttributeSame([], 'operations', $this->SUT);
+        $this->assertAttributeSame(array(), 'operations', $this->SUT);
 
         $operation1 = new FakeOperation('');
         $this->SUT->addOperation($operation1);
 
-        $this->assertAttributeSame([
+        $this->assertAttributeSame(array(
             $operation1,
-        ], 'operations', $this->SUT);
+        ), 'operations', $this->SUT);
 
         $operation2 = new FakeOperation('');
         $this->SUT->addOperation($operation2);
 
-        $this->assertAttributeSame([
+        $this->assertAttributeSame(array(
             $operation1,
             $operation2,
-        ], 'operations', $this->SUT);
+        ), 'operations', $this->SUT);
     }
 
     public function test_it_outputs_with_no_supported_url_generator()
     {
-        $this->SUT = new Outputter($this->operationHandlers, [
+        $this->SUT = new Outputter($this->operationHandlers, array(
             new FakeUrlGenerator(false, '', ''),
-        ]);
+        ));
 
         $this->SUT->addOperation(new FakeOperation('operation 1'));
         $this->SUT->addOperation(new FakeOperation('operation 2'));
@@ -90,9 +90,9 @@ TEXT;
 
     public function test_it_outputs_with_no_supported_operation_handler()
     {
-        $this->SUT = new Outputter([
+        $this->SUT = new Outputter(array(
             new FakeHandler(false, '', ''),
-        ], $this->urlGenerators);
+        ), $this->urlGenerators);
 
         $this->SUT->addOperation(new FakeOperation('operation 1'));
         $this->SUT->addOperation(new FakeOperation('operation 2'));

--- a/tests/resources/FakeHandler.php
+++ b/tests/resources/FakeHandler.php
@@ -61,12 +61,12 @@ class FakeHandler implements OperationHandler
     public function getOutput(OperationInterface $operation, UrlGenerator $urlGenerator = null)
     {
         if (!($operation instanceof FakeOperation)) {
-            return [];
+            return array();
         }
 
-        $output = [
+        $output = array(
             ' - ' . $this->output . ', ' . $operation->getText(),
-        ];
+        );
 
         if ($urlGenerator) {
             $output[] = '   ' . $urlGenerator->generateCompareUrl($this->sourceUrl, new Version('', '', ''), $this->sourceUrl, new Version('', '', ''));


### PR DESCRIPTION
This pull request does the following changes to lower PHP requirement from 5.4+ to 5.3+:

1. Replaces the short array syntax (`[]`) in the source files to the traditional array syntax (`array()`).
2. Removes direct array dereferencing on call in tests by using an intermediate variable.
3. Changes Composer platform requirement from `php >= 5.4.0` to `php >= 5.3.0`.
4. Adds PHP 5.3 to the Travis CI matrix.
