### PR TITLE
Adding configurable post update priority

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -25,7 +25,7 @@ one in your `.composer` home directory (like
 
 ## Configuration available
 
-Currently, there is 2 configurable behaviors:
+The available configuration options are listed below:
 
 ### Gitlab hosts
 
@@ -52,3 +52,25 @@ should consider as Gitlab instance.
 
 See [the full documentation of this feature](autocommit.md).
 
+### Post Update Priority
+
+The option `post-update-priority` can set a custom event priority for
+the composer `post-update-cmd` event. This will delay the changelog
+printing and [autocommit feature](autocommit.md).
+
+The default value is set to `-1`. The value must be a signed int.
+A lower event priority also means its run later.
+
+This default behaviour ensures that you can run user defined
+[composer scripts](https://getcomposer.org/doc/articles/scripts.md#command-events)
+for the `post-update-cmd` event before.
+
+```json
+{
+    "extra": {
+        "composer-changelogs": {
+            "post-update-priority": -1
+        }
+    }
+}
+```

--- a/src/ChangelogsPlugin.php
+++ b/src/ChangelogsPlugin.php
@@ -42,6 +42,9 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
     /** @var Config */
     private $config;
 
+    /** @var int */
+    private static $postUpdatePriority = -1;
+
     /**
      * {@inheritdoc}
      */
@@ -73,7 +76,7 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
                 ['postPackageOperation'],
             ],
             ScriptEvents::POST_UPDATE_CMD => [
-                ['postUpdate'],
+                ['postUpdate', static::$postUpdatePriority],
             ],
         ];
     }
@@ -129,6 +132,8 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
             $this->configLocator->getConfig(self::EXTRA_KEY),
             $this->configLocator->getPath(self::EXTRA_KEY)
         );
+
+        static::$postUpdatePriority = $this->config->getPostUpdatePriority();
 
         if (count($builder->getWarnings()) > 0) {
             $this->io->writeError('<error>Invalid config for composer-changelogs plugin:</error>');

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -25,18 +25,23 @@ class Config
     /** @var string[] */
     private $gitlabHosts;
 
+    /** @var int */
+    private $postUpdatePriority;
+
     /**
      * @param string      $commitAuto
      * @param string|null $commitBinFile
      * @param string      $commitMessage
      * @param string[]    $gitlabHosts
+     * @param int         $postUpdatePriority
      */
-    public function __construct($commitAuto, $commitBinFile, $commitMessage, array $gitlabHosts)
+    public function __construct($commitAuto, $commitBinFile, $commitMessage, array $gitlabHosts, $postUpdatePriority)
     {
         $this->commitAuto = $commitAuto;
         $this->commitBinFile = $commitBinFile;
         $this->commitMessage = $commitMessage;
         $this->gitlabHosts = $gitlabHosts;
+        $this->postUpdatePriority = $postUpdatePriority;
     }
 
     /**
@@ -69,5 +74,13 @@ class Config
     public function getGitlabHosts()
     {
         return $this->gitlabHosts;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPostUpdatePriority()
+    {
+        return $this->postUpdatePriority;
     }
 }

--- a/src/Config/ConfigBuilder.php
+++ b/src/Config/ConfigBuilder.php
@@ -38,6 +38,7 @@ class ConfigBuilder
         $commitBinFile = null;
         $commitMessage = 'Update dependencies';
         $gitlabHosts = [];
+        $postUpdatePriority = -1;
 
         if (array_key_exists('commit-auto', $extra)) {
             if (in_array($extra['commit-auto'], self::$validCommitAutoValues, true)) {
@@ -93,7 +94,15 @@ class ConfigBuilder
             }
         }
 
-        return new Config($commitAuto, $commitBinFile, $commitMessage, $gitlabHosts);
+        if (array_key_exists('post-update-priority', $extra)) {
+            if (!preg_match('/^-?\d+$/', $extra['post-update-priority'])) {
+                $this->warnings[] = '"post-update-priority" is specified but not an integer. Ignoring and using default commit event priority.';
+            } else {
+                $postUpdatePriority = (int) $extra['post-update-priority'];
+            }
+        }
+
+        return new Config($commitAuto, $commitBinFile, $commitMessage, $gitlabHosts, $postUpdatePriority);
     }
 
     /**

--- a/tests/ChangelogsPluginTest.php
+++ b/tests/ChangelogsPluginTest.php
@@ -172,6 +172,25 @@ OUTPUT;
         $this->assertSame($expectedOutput, $this->io->getOutput());
     }
 
+    public function test_post_update_event_priority_is_handled()
+    {
+        $this->config->merge([
+            'config' => [
+                'home' => realpath(__DIR__ . '/fixtures/other-post-update-priority'),
+            ],
+        ]);
+
+        $this->addComposerPlugin(new ChangelogsPlugin());
+
+        $eventDispatcherReflection = new \ReflectionClass($this->composer->getEventDispatcher());
+        $eventListenerReflection = $eventDispatcherReflection->getProperty('listeners');
+        $eventListenerReflection->setAccessible(true);
+        $eventListeners = $eventListenerReflection->getValue($this->composer->getEventDispatcher());
+
+        $this->assertArrayHasKey(ScriptEvents::POST_UPDATE_CMD, $eventListeners);
+        $this->assertArrayHasKey(-1337, $eventListeners[ScriptEvents::POST_UPDATE_CMD]);
+    }
+
     public function test_it_commits_with_always_option()
     {
         $this->config->merge([

--- a/tests/Config/ConfigBuilderTest.php
+++ b/tests/Config/ConfigBuilderTest.php
@@ -39,6 +39,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
+        static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(0, $this->SUT->getWarnings());
     }
@@ -55,6 +56,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
+        static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
         static::assertContains('Invalid value "foo" for option "commit-auto"', $this->SUT->getWarnings()[0]);
@@ -73,6 +75,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
+        static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
         static::assertContains('"commit-bin-file" is specified but "commit-auto" option is set to "never". Ignoring.', $this->SUT->getWarnings()[0]);
@@ -91,6 +94,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertSame('always', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
+        static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
         static::assertContains('The file pointed by the option "commit-bin-file" was not found. Ignoring.', $this->SUT->getWarnings()[0]);
@@ -108,9 +112,28 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertSame('ask', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
+        static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
         static::assertContains('"commit-auto" is set to "ask" but "commit-bin-file" was not specified.', $this->SUT->getWarnings()[0]);
+    }
+
+    public function test_it_warns_when_commit_event_priority_value_is_invalid()
+    {
+        $extra = [
+            'post-update-priority' => 'invalid-priority',
+        ];
+
+        $config = $this->SUT->build($extra, __DIR__);
+
+        static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
+        static::assertSame('never', $config->getCommitAuto());
+        static::assertNull($config->getCommitBinFile());
+        static::assertEmpty($config->getGitlabHosts());
+        static::assertEquals(-1, $config->getPostUpdatePriority());
+
+        static::assertCount(1, $this->SUT->getWarnings());
+        static::assertContains('"post-update-priority" is specified but not an integer. Ignoring and using default commit event priority.', $this->SUT->getWarnings()[0]);
     }
 
     public function test_it_warns_when_gitlab_hosts_is_not_an_array()
@@ -125,6 +148,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
+        static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
         static::assertContains('"gitlab-hosts" is specified but should be an array. Ignoring.', $this->SUT->getWarnings()[0]);
@@ -136,6 +160,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
             'commit-auto' => 'ask',
             'commit-bin-file' => self::COMMIT_BIN_FILE,
             'gitlab-hosts' => ['gitlab.company1.com', 'gitlab.company2.com'],
+            'post-update-priority' => '-1337',
         ];
 
         $config = $this->SUT->build($extra, __DIR__);
@@ -144,6 +169,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         static::assertSame('ask', $config->getCommitAuto());
         static::assertSame($this->absoluteCommitBinFile, $config->getCommitBinFile());
         static::assertCount(2, $config->getGitlabHosts());
+        static::assertEquals(-1337, $config->getPostUpdatePriority());
 
         static::assertCount(0, $this->SUT->getWarnings());
     }

--- a/tests/fixtures/other-post-update-priority/composer.json
+++ b/tests/fixtures/other-post-update-priority/composer.json
@@ -1,0 +1,7 @@
+{
+    "extra": {
+        "composer-changelogs": {
+            "post-update-priority": -1337
+        }
+    }
+}


### PR DESCRIPTION
This resolves #45 by adding a new config for post update priority and lowering the default event priority.
Setting the default event priority of "post-update-cmd" to `-1` will run the auto commit and printed changelog just after user defined composer scripts for "post-update-cmd".

Since the method `getSubscribedEvents` needs to be static it wasn't possible to pass the config value in a nice way. So I am setting it in the `activate` method to a static var. But this shouldn't be a problem because the `activate` method is always called before registering plugin event subscriptions in composer (See `Composer\Plugin\PluginManager::addPlugin`). @pyrech please give me some feedback on this.

I will try writing tests for that weird behavior and provide documentation.