### PR TITLE
Enhancement: Add PHP 7.1, 7.2, and 7.3 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
         - php: 5.6
           env: deps=high coverage=true
         - php: 7.0
+        - php: 7.1
+        - php: 7.2
+        - php: 7.3
 
 env:
     global:


### PR DESCRIPTION
This PR

* [x] adds PHP 7.1, 7.2, and 7.3 to the Travis CI build matrix