### PR TITLE
Fix: Explicitly return null

### DIFF
--- a/src/Outputter.php
+++ b/src/Outputter.php
@@ -114,7 +114,7 @@ class Outputter
             }
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -130,6 +130,6 @@ class Outputter
             }
         }
 
-        return;
+        return null;
     }
 }


### PR DESCRIPTION
This PR

* [x] explicitly returns `null` when a handler or URL generator wasn't found