### PR TITLE
Fix: Return early when no URL generator was found

### DIFF
--- a/src/Outputter.php
+++ b/src/Outputter.php
@@ -95,6 +95,10 @@ class Outputter
             $operationHandler->extractSourceUrl($operation)
         );
 
+        if (null === $urlGenerator) {
+            return;
+        }
+
         $output = array_merge(
             $output,
             $operationHandler->getOutput($operation, $urlGenerator)


### PR DESCRIPTION
This PR

* [x] returns early when a URL generator was not found