### PR TITLE
Fix: Simplify fully-qualified class names

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -11,38 +11,35 @@
 
 namespace Pyrech\ComposerChangelogs;
 
-use Pyrech\ComposerChangelogs\OperationHandler\OperationHandler;
-use Pyrech\ComposerChangelogs\UrlGenerator\UrlGenerator;
-
 class Factory
 {
     /**
-     * @return OperationHandler[]
+     * @return OperationHandler\OperationHandler[]
      */
     public static function createOperationHandlers()
     {
         return [
-            new \Pyrech\ComposerChangelogs\OperationHandler\InstallHandler(),
-            new \Pyrech\ComposerChangelogs\OperationHandler\UpdateHandler(),
-            new \Pyrech\ComposerChangelogs\OperationHandler\UninstallHandler(),
+            new OperationHandler\InstallHandler(),
+            new OperationHandler\UpdateHandler(),
+            new OperationHandler\UninstallHandler(),
         ];
     }
 
     /**
      * @param string[] $gitlabHosts
      *
-     * @return UrlGenerator[]
+     * @return UrlGenerator\UrlGenerator[]
      */
     public static function createUrlGenerators(array $gitlabHosts = [])
     {
         $hosts = [
-            new \Pyrech\ComposerChangelogs\UrlGenerator\GithubUrlGenerator(),
-            new \Pyrech\ComposerChangelogs\UrlGenerator\BitbucketUrlGenerator(),
-            new \Pyrech\ComposerChangelogs\UrlGenerator\WordPressUrlGenerator(),
+            new UrlGenerator\GithubUrlGenerator(),
+            new UrlGenerator\BitbucketUrlGenerator(),
+            new UrlGenerator\WordPressUrlGenerator(),
         ];
 
         foreach ($gitlabHosts as $gitlabHost) {
-            $hosts[] = new \Pyrech\ComposerChangelogs\UrlGenerator\GitlabUrlGenerator($gitlabHost);
+            $hosts[] = new UrlGenerator\GitlabUrlGenerator($gitlabHost);
         }
 
         return $hosts;


### PR DESCRIPTION
This PR

* [x] simplifies fully-qualified class names