### PR TITLE
Fix: Remove HHVM from Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
 
 matrix:
     include:
-        - php: hhvm
         - php: 5.4
           env: check_cs=true
         - php: 5.5


### PR DESCRIPTION
This PR

* removes `hhvm` from the Travis build matrix

💁‍♂️ I think that with https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html it is clear that we don't need to worry about HHVM anymore. What do you think?