### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ composer.phar
 
 # CS
 .php_cs.cache
+
+# PHPUnit
+.phpunit.result.cache

--- a/.php_cs
+++ b/.php_cs
@@ -9,31 +9,53 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 EOF;
 
-Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
+$finder = \PhpCsFixer\Finder::create()
     ->in(array(__DIR__))
 ;
 
-return Symfony\CS\Config\Config::create()
+return \PhpCsFixer\Config::create()
     // Set to Symfony Level (PSR1 PSR2)
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers(array(
-        'header_comment',           // Add the provided header comment ($header)
-        'newline_after_open_tag',   // Force new line after <?php
-        'ordered_use',              // Order "use" alphabetically
-        'short_array_syntax',       // Replace array() by []
-        '-empty_return',            // Keep return null;
-        'phpdoc_order',             // Clean up the /** php doc */
-        'concat_with_spaces',       // Force space around concatenation operator
-        '-align_double_arrow',      // Force no double arrow align
-        'unalign_double_arrow',     // Keep double arrow simple
-        '-align_equals',            // Force no aligned equals
-        'unalign_equals',           // Keep equals simple
-        'strict',                   // Strict comparison
-        'strict_param',             // Functions should use $strict param
-        '-heredoc_to_nowdoc',        // Do not convert heredoc to nowdoc
-    ))
+    ->setRules([
+        '@Symfony' => true,
+
+        // Add the provided header comment ($header)
+        'header_comment' => [
+            'header' => $header
+        ],
+
+        // Force new line after <?php
+        'blank_line_after_opening_tag' => true,
+
+        // Order "use" alphabetically
+        'ordered_imports' => true,
+
+        // Replace array() by []
+        'array_syntax' => [
+            'syntax' => 'short'
+        ],
+
+        // Keep return null;
+        'simplified_null_return' => false,
+
+        // Clean up the /** php doc */
+        'phpdoc_order' => true,
+
+        // Force space around concatenation operator
+        'concat_space' => [
+            'spacing' => 'one'
+        ],
+
+        // Strict comparison
+        'strict_comparison' => true,
+
+        // Functions should use $strict param
+        'strict_param' => true,
+
+        // Do not convert heredoc to nowdoc
+        'heredoc_to_nowdoc' => false
+    ])
     ->setUsingCache(true)
-    ->finder($finder)
+    ->setFinder($finder)
+    ->setRiskyAllowed(true);
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,12 @@ cache:
 
 matrix:
     include:
-        - php: 5.4
-          env: check_cs=true
-        - php: 5.5
-        - php: 5.6
-          env: deps=low coverage=true
-        - php: 5.6
-          env: deps=high coverage=true
-        - php: 7.0
         - php: 7.1
+          env: deps=low coverage=true
         - php: 7.2
+          env: check_cs=true
         - php: 7.3
+          env: deps=high coverage=true
 
 env:
     global:
@@ -39,7 +34,7 @@ script:
     - if [ "$coverage" = "true" ]; then vendor/bin/phpunit --coverage-clover=coverage; fi;
     - if [ "$coverage" = "true" ]; then xdebug-disable; fi;
     - if [ "$coverage" != "true" ]; then vendor/bin/phpunit; fi;
-    - if [ "$check_cs" = "true" ]; then vendor/bin/php-cs-fixer fix --config-file=.php_cs --dry-run --diff; fi;
+    - if [ "$check_cs" = "true" ]; then vendor/bin/php-cs-fixer fix --config=.php_cs --dry-run --diff; fi;
 
 after_script:
     - if [ "$coverage" = "true" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Use [PHP CS fixer](http://cs.sensiolabs.org/) to make your code compliant with
 composer-changelogs's coding standards:
 
 ```shell
-vendor/bin/php-cs-fixer fix --config-file=.php_cs --diff
+vendor/bin/php-cs-fixer fix --config=.php_cs --diff
 ```
 or the alias:
 ```shell

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "composer/composer": "^1.9",
         "composer/semver": "^1.5",
+        "friendsofphp/php-cs-fixer": "^2.15",
         "phpunit/phpunit": "^8.3"
     },
     "config": {
@@ -44,8 +45,8 @@
         }
     },
     "scripts": {
-        "cs": "vendor/bin/php-cs-fixer fix --config-file=.php_cs --diff --dry-run --verbose",
-        "fix-cs": "vendor/bin/php-cs-fixer fix --config-file=.php_cs --diff --verbose",
+        "cs": "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --dry-run --verbose",
+        "fix-cs": "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --verbose",
         "test": "vendor/bin/phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "composer/composer": "^1.9",
         "composer/semver": "^1.5",
         "friendsofphp/php-cs-fixer": "^2.15",
-        "phpunit/phpunit": "^8.3"
+        "phpunit/phpunit": "^7.5"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,13 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.1",
         "composer-plugin-api": "^1.0 || ^1.1"
     },
     "require-dev": {
-        "composer/composer": "~1.0.0-alpha10@dev",
-        "composer/semver": "1.2.0",
-        "friendsofphp/php-cs-fixer": "~1.5",
-        "phpunit/phpunit": "^4.8"
+        "composer/composer": "^1.9",
+        "composer/semver": "^1.5",
+        "phpunit/phpunit": "^8.3"
     },
     "config": {
         "sort-packages": true

--- a/src/ChangelogsPlugin.php
+++ b/src/ChangelogsPlugin.php
@@ -112,7 +112,7 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
     {
         foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(__DIR__, \FilesystemIterator::SKIP_DOTS)) as $file) {
             if ('.php' === substr($file, 0, -4)) {
-                class_exists(__NAMESPACE__.str_replace('/', '\\', substr($file, \strlen(__DIR__), -4)));
+                class_exists(__NAMESPACE__ . str_replace('/', '\\', substr($file, \strlen(__DIR__), -4)));
             }
         }
     }

--- a/src/Config/ConfigBuilder.php
+++ b/src/Config/ConfigBuilder.php
@@ -54,7 +54,7 @@ class ConfigBuilder
         }
 
         if (array_key_exists('commit-bin-file', $extra)) {
-            if ($commitAuto === 'never') {
+            if ('never' === $commitAuto) {
                 $this->warnings[] = '"commit-bin-file" is specified but "commit-auto" option is set to "never". Ignoring.';
             } else {
                 $file = realpath(
@@ -70,7 +70,7 @@ class ConfigBuilder
                 }
             }
         } else {
-            if ($commitAuto !== 'never') {
+            if ('never' !== $commitAuto) {
                 $this->warnings[] = sprintf(
                     '"commit-auto" is set to "%s" but "commit-bin-file" was not specified.',
                     $commitAuto
@@ -79,7 +79,7 @@ class ConfigBuilder
         }
 
         if (array_key_exists('commit-message', $extra)) {
-            if (strlen(trim($extra['commit-message'])) === 0) {
+            if (0 === strlen(trim($extra['commit-message']))) {
                 $this->warnings[] = '"commit-message" is specified but empty. Ignoring and using default commit message.';
             } else {
                 $commitMessage = $extra['commit-message'];

--- a/src/Outputter.php
+++ b/src/Outputter.php
@@ -45,6 +45,15 @@ class Outputter
         $this->operations[] = $operation;
     }
 
+
+    /**
+     * @return OperationInterface[]
+     */
+    public function getOperations()
+    {
+        return $this->operations;
+    }
+
     /**
      * @return bool
      */

--- a/src/Outputter.php
+++ b/src/Outputter.php
@@ -45,7 +45,6 @@ class Outputter
         $this->operations[] = $operation;
     }
 
-
     /**
      * @return OperationInterface[]
      */

--- a/src/UrlGenerator/GitBasedUrlGenerator.php
+++ b/src/UrlGenerator/GitBasedUrlGenerator.php
@@ -30,7 +30,7 @@ abstract class GitBasedUrlGenerator implements UrlGenerator
      */
     public function supports($sourceUrl)
     {
-        return strpos($sourceUrl, $this->getDomain()) !== false;
+        return false !== strpos($sourceUrl, $this->getDomain());
     }
 
     /**
@@ -56,7 +56,7 @@ abstract class GitBasedUrlGenerator implements UrlGenerator
             '%s://%s%s',
             $sourceUrl['scheme'],
             $sourceUrl['host'],
-            $pos === false ? $sourceUrl['path'] : substr($sourceUrl['path'], 0, strrpos($sourceUrl['path'], '.git'))
+            false === $pos ? $sourceUrl['path'] : substr($sourceUrl['path'], 0, strrpos($sourceUrl['path'], '.git'))
         );
     }
 
@@ -115,7 +115,7 @@ abstract class GitBasedUrlGenerator implements UrlGenerator
      */
     private function isSshUrl($url)
     {
-        return strpos($url, 'git@') !== false;
+        return false !== strpos($url, 'git@');
     }
 
     /**

--- a/src/UrlGenerator/WordPressUrlGenerator.php
+++ b/src/UrlGenerator/WordPressUrlGenerator.php
@@ -25,7 +25,7 @@ class WordPressUrlGenerator implements UrlGenerator
      */
     public function supports($sourceUrl)
     {
-        return strpos($sourceUrl, self::DOMAIN) !== false;
+        return false !== strpos($sourceUrl, self::DOMAIN);
     }
 
     /**

--- a/src/Util/FileSystemHelper.php
+++ b/src/Util/FileSystemHelper.php
@@ -27,7 +27,7 @@ class FileSystemHelper
     {
         return strspn($file, '/\\', 0, 1)
             || (strlen($file) > 3 && ctype_alpha($file[0])
-                && substr($file, 1, 1) === ':'
+                && ':' === substr($file, 1, 1)
                 && strspn($file, '/\\', 2, 1)
             )
             || null !== parse_url($file, PHP_URL_SCHEME)

--- a/src/Version.php
+++ b/src/Version.php
@@ -70,7 +70,7 @@ class Version
 
     /**
      * Return the version string for CLI Output
-     * In cas of dev version is adds the vcs hash
+     * In case of dev version is adds the vcs hash.
      *
      * @return string
      */

--- a/src/Version.php
+++ b/src/Version.php
@@ -65,7 +65,7 @@ class Version
      */
     public function isDev()
     {
-        return substr($this->name, 0, 4) === 'dev-' || substr($this->name, -4) === '-dev';
+        return 'dev-' === substr($this->name, 0, 4) || '-dev' === substr($this->name, -4);
     }
 
     /**

--- a/tests/ChangelogsPluginTest.php
+++ b/tests/ChangelogsPluginTest.php
@@ -27,9 +27,10 @@ use Composer\Plugin\PluginInterface;
 use Composer\Plugin\PluginManager;
 use Composer\Repository\CompositeRepository;
 use Composer\Script\ScriptEvents;
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\ChangelogsPlugin;
 
-class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
+class ChangelogsPluginTest extends TestCase
 {
     /** @var BufferIO */
     private $io;
@@ -46,7 +47,7 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tempDir = __DIR__ . '/temp';
         $this->config = new Config(false, realpath(__DIR__ . '/fixtures/local'));
@@ -71,7 +72,7 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         self::cleanTempDir();
     }
@@ -98,8 +99,6 @@ class ChangelogsPluginTest extends \PHPUnit_Framework_TestCase
         $this->addComposerPlugin($plugin);
 
         $this->assertSame([$plugin], $this->composer->getPluginManager()->getPlugins());
-        $this->assertAttributeInstanceOf('Composer\IO\IOInterface', 'io', $plugin);
-        $this->assertAttributeInstanceOf('Pyrech\ComposerChangelogs\Outputter', 'outputter', $plugin);
     }
 
     public function test_it_receives_event()

--- a/tests/Config/ConfigBuilderTest.php
+++ b/tests/Config/ConfigBuilderTest.php
@@ -11,9 +11,11 @@
 
 namespace Pyrech\ComposerChangelogs\tests\Config;
 
+use PHPUnit\Framework\TestCase;
+use Pyrech\ComposerChangelogs\Config\Config;
 use Pyrech\ComposerChangelogs\Config\ConfigBuilder;
 
-class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
+class ConfigBuilderTest extends TestCase
 {
     const COMMIT_BIN_FILE = '../fixtures/bin/fake.sh';
 
@@ -23,7 +25,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
     /** @var ConfigBuilder */
     private $SUT;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->absoluteCommitBinFile = realpath(__DIR__ . '/' . self::COMMIT_BIN_FILE);
         $this->SUT = new ConfigBuilder();
@@ -35,7 +37,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
         $config = $this->SUT->build($extra, __DIR__);
 
-        static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
+        static::assertInstanceOf(Config::class, $config);
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
@@ -52,14 +54,15 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
         $config = $this->SUT->build($extra, __DIR__);
 
-        static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
+        static::assertInstanceOf(Config::class, $config);
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
         static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('Invalid value "foo" for option "commit-auto"', $this->SUT->getWarnings()[0]);
+
+        static::assertStringContainsString('Invalid value "foo" for option "commit-auto"', $this->SUT->getWarnings()[0]);
     }
 
     public function test_it_warns_when_specifying_commit_bin_file_and_never_auto_commit()
@@ -71,14 +74,14 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
         $config = $this->SUT->build($extra, __DIR__);
 
-        static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
+        static::assertInstanceOf(Config::class, $config);
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
         static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('"commit-bin-file" is specified but "commit-auto" option is set to "never". Ignoring.', $this->SUT->getWarnings()[0]);
+        static::assertStringContainsString('"commit-bin-file" is specified but "commit-auto" option is set to "never". Ignoring.', $this->SUT->getWarnings()[0]);
     }
 
     public function test_it_warns_when_specified_commit_bin_file_was_not_found()
@@ -90,14 +93,14 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
         $config = $this->SUT->build($extra, __DIR__);
 
-        static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
+        static::assertInstanceOf(Config::class, $config);
         static::assertSame('always', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
         static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('The file pointed by the option "commit-bin-file" was not found. Ignoring.', $this->SUT->getWarnings()[0]);
+        static::assertStringContainsString('The file pointed by the option "commit-bin-file" was not found. Ignoring.', $this->SUT->getWarnings()[0]);
     }
 
     public function test_it_warns_when_commit_bin_file_should_have_been_specified()
@@ -108,14 +111,14 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
         $config = $this->SUT->build($extra, __DIR__);
 
-        static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
+        static::assertInstanceOf(Config::class, $config);
         static::assertSame('ask', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
         static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('"commit-auto" is set to "ask" but "commit-bin-file" was not specified.', $this->SUT->getWarnings()[0]);
+        static::assertStringContainsString('"commit-auto" is set to "ask" but "commit-bin-file" was not specified.', $this->SUT->getWarnings()[0]);
     }
 
     public function test_it_warns_when_commit_event_priority_value_is_invalid()
@@ -126,14 +129,14 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
         $config = $this->SUT->build($extra, __DIR__);
 
-        static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
+        static::assertInstanceOf(Config::class, $config);
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
         static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('"post-update-priority" is specified but not an integer. Ignoring and using default commit event priority.', $this->SUT->getWarnings()[0]);
+        static::assertStringContainsString('"post-update-priority" is specified but not an integer. Ignoring and using default commit event priority.', $this->SUT->getWarnings()[0]);
     }
 
     public function test_it_warns_when_gitlab_hosts_is_not_an_array()
@@ -144,14 +147,14 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
         $config = $this->SUT->build($extra, __DIR__);
 
-        static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
+        static::assertInstanceOf(Config::class, $config);
         static::assertSame('never', $config->getCommitAuto());
         static::assertNull($config->getCommitBinFile());
         static::assertEmpty($config->getGitlabHosts());
         static::assertEquals(-1, $config->getPostUpdatePriority());
 
         static::assertCount(1, $this->SUT->getWarnings());
-        static::assertContains('"gitlab-hosts" is specified but should be an array. Ignoring.', $this->SUT->getWarnings()[0]);
+        static::assertStringContainsString('"gitlab-hosts" is specified but should be an array. Ignoring.', $this->SUT->getWarnings()[0]);
     }
 
     public function test_it_accepts_valid_setup()
@@ -165,7 +168,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
         $config = $this->SUT->build($extra, __DIR__);
 
-        static::assertInstanceOf('Pyrech\ComposerChangelogs\Config\Config', $config);
+        static::assertInstanceOf(Config::class, $config);
         static::assertSame('ask', $config->getCommitAuto());
         static::assertSame($this->absoluteCommitBinFile, $config->getCommitBinFile());
         static::assertCount(2, $config->getGitlabHosts());

--- a/tests/Config/ConfigLocatorTest.php
+++ b/tests/Config/ConfigLocatorTest.php
@@ -14,9 +14,10 @@ namespace Pyrech\ComposerChangelogs\tests;
 use Composer\Composer;
 use Composer\Config;
 use Composer\Package\RootPackage;
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\Config\ConfigLocator;
 
-class ConfigLocatorTest extends \PHPUnit_Framework_TestCase
+class ConfigLocatorTest extends TestCase
 {
     /** @var string */
     private $localConfigPath;
@@ -36,7 +37,7 @@ class ConfigLocatorTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->localConfigPath = realpath(__DIR__ . '/../fixtures/local');
         $this->globalConfigPath = realpath(__DIR__ . '/../fixtures/home');

--- a/tests/OperationHandler/InstallHandlerTest.php
+++ b/tests/OperationHandler/InstallHandlerTest.php
@@ -13,16 +13,17 @@ namespace Pyrech\ComposerChangelogs\tests\OperationHandler;
 
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\Package\Package;
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\OperationHandler\InstallHandler;
 use Pyrech\ComposerChangelogs\tests\resources\FakeOperation;
 use Pyrech\ComposerChangelogs\tests\resources\FakeUrlGenerator;
 
-class InstallHandlerTest extends \PHPUnit_Framework_TestCase
+class InstallHandlerTest extends TestCase
 {
     /** @var InstallHandler */
     private $SUT;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->SUT = new InstallHandler();
     }
@@ -54,12 +55,11 @@ class InstallHandlerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Operation should be an instance of InstallOperation
-     */
     public function test_it_throws_exception_when_extracting_source_url_from_non_install_operation()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Operation should be an instance of InstallOperation');
+
         $this->SUT->extractSourceUrl(new FakeOperation(''));
     }
 
@@ -148,12 +148,11 @@ class InstallHandlerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Operation should be an instance of InstallOperation
-     */
     public function test_it_throws_exception_when_getting_output_from_non_install_operation()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Operation should be an instance of InstallOperation');
+
         $this->SUT->getOutput(new FakeOperation(''));
     }
 }

--- a/tests/OperationHandler/UninstallHandlerTest.php
+++ b/tests/OperationHandler/UninstallHandlerTest.php
@@ -13,16 +13,17 @@ namespace Pyrech\ComposerChangelogs\tests\OperationHandler;
 
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\Package\Package;
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\OperationHandler\UninstallHandler;
 use Pyrech\ComposerChangelogs\tests\resources\FakeOperation;
 use Pyrech\ComposerChangelogs\tests\resources\FakeUrlGenerator;
 
-class UninstallHandlerTest extends \PHPUnit_Framework_TestCase
+class UninstallHandlerTest extends TestCase
 {
     /** @var UninstallHandler */
     private $SUT;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->SUT = new UninstallHandler();
     }
@@ -54,12 +55,11 @@ class UninstallHandlerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Operation should be an instance of UninstallOperation
-     */
     public function test_it_throws_exception_when_extracting_source_url_from_non_uninstall_operation()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Operation should be an instance of UninstallOperation');
+
         $this->SUT->extractSourceUrl(new FakeOperation(''));
     }
 
@@ -146,12 +146,11 @@ class UninstallHandlerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Operation should be an instance of UninstallOperation
-     */
     public function test_it_throws_exception_when_getting_output_from_non_uninstall_operation()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Operation should be an instance of UninstallOperation');
+
         $this->SUT->getOutput(new FakeOperation(''));
     }
 }

--- a/tests/OperationHandler/UpdateHandlerTest.php
+++ b/tests/OperationHandler/UpdateHandlerTest.php
@@ -13,16 +13,17 @@ namespace Pyrech\ComposerChangelogs\tests\OperationHandler;
 
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Package\Package;
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\OperationHandler\UpdateHandler;
 use Pyrech\ComposerChangelogs\tests\resources\FakeOperation;
 use Pyrech\ComposerChangelogs\tests\resources\FakeUrlGenerator;
 
-class UpdateHandlerTest extends \PHPUnit_Framework_TestCase
+class UpdateHandlerTest extends TestCase
 {
     /** @var UpdateHandler */
     private $SUT;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->SUT = new UpdateHandler();
     }
@@ -58,12 +59,11 @@ class UpdateHandlerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Operation should be an instance of UpdateOperation
-     */
     public function test_it_throws_exception_when_extracting_source_url_from_non_update_operation()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Operation should be an instance of UpdateOperation');
+
         $this->SUT->extractSourceUrl(new FakeOperation(''));
     }
 
@@ -160,12 +160,11 @@ class UpdateHandlerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Operation should be an instance of UpdateOperation
-     */
     public function test_it_throws_exception_when_getting_output_from_non_update_operation()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Operation should be an instance of UpdateOperation');
+
         $this->SUT->getOutput(new FakeOperation(''));
     }
 

--- a/tests/OutputterTest.php
+++ b/tests/OutputterTest.php
@@ -11,6 +11,7 @@
 
 namespace Pyrech\ComposerChangelogs\tests;
 
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\OperationHandler\OperationHandler;
 use Pyrech\ComposerChangelogs\Outputter;
 use Pyrech\ComposerChangelogs\tests\resources\FakeHandler;
@@ -18,7 +19,7 @@ use Pyrech\ComposerChangelogs\tests\resources\FakeOperation;
 use Pyrech\ComposerChangelogs\tests\resources\FakeUrlGenerator;
 use Pyrech\ComposerChangelogs\UrlGenerator\UrlGenerator;
 
-class OutputterTest extends \PHPUnit_Framework_TestCase
+class OutputterTest extends TestCase
 {
     /** @var Outputter */
     private $SUT;
@@ -29,7 +30,7 @@ class OutputterTest extends \PHPUnit_Framework_TestCase
     /** @var UrlGenerator[] */
     private $urlGenerators;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->operationHandlers = [
             new FakeHandler(false, 'http://domain1', 'Output handler 1'),
@@ -48,22 +49,20 @@ class OutputterTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_adds_operation()
     {
-        $this->assertAttributeSame([], 'operations', $this->SUT);
+        $this->assertSame([], $this->SUT->getOperations());
 
         $operation1 = new FakeOperation('');
         $this->SUT->addOperation($operation1);
 
-        $this->assertAttributeSame([
-            $operation1,
-        ], 'operations', $this->SUT);
+        $this->assertSame([$operation1], $this->SUT->getOperations());
 
         $operation2 = new FakeOperation('');
         $this->SUT->addOperation($operation2);
 
-        $this->assertAttributeSame([
+        $this->assertSame([
             $operation1,
             $operation2,
-        ], 'operations', $this->SUT);
+        ], $this->SUT->getOperations());
     }
 
     public function test_it_outputs_with_no_supported_url_generator()

--- a/tests/UrlGenerator/BitbucketUrlGeneratorTest.php
+++ b/tests/UrlGenerator/BitbucketUrlGeneratorTest.php
@@ -11,15 +11,16 @@
 
 namespace Pyrech\ComposerChangelogs\tests\UrlGenerator;
 
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\UrlGenerator\BitbucketUrlGenerator;
 use Pyrech\ComposerChangelogs\Version;
 
-class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
+class BitbucketUrlGeneratorTest extends TestCase
 {
     /** @var BitbucketUrlGenerator */
     private $SUT;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->SUT = new BitbucketUrlGenerator();
     }
@@ -145,12 +146,11 @@ class BitbucketUrlGeneratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Unrecognized url format for bitbucket.org ("https://bitbucket.org/acme2")
-     */
     public function test_it_throws_exception_when_generating_compare_urls_across_forks_if_a_source_url_is_invalid()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unrecognized url format for bitbucket.org ("https://bitbucket.org/acme2")');
+
         $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
         $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
 

--- a/tests/UrlGenerator/GithubUrlGeneratorTest.php
+++ b/tests/UrlGenerator/GithubUrlGeneratorTest.php
@@ -11,15 +11,16 @@
 
 namespace Pyrech\ComposerChangelogs\tests\UrlGenerator;
 
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\UrlGenerator\GithubUrlGenerator;
 use Pyrech\ComposerChangelogs\Version;
 
-class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
+class GithubUrlGeneratorTest extends TestCase
 {
     /** @var GithubUrlGenerator */
     private $SUT;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->SUT = new GithubUrlGenerator();
     }
@@ -145,12 +146,11 @@ class GithubUrlGeneratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Unrecognized url format for github.com ("https://github.com/acme2")
-     */
     public function test_it_throws_exception_when_generating_compare_urls_across_forks_if_a_source_url_is_invalid()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unrecognized url format for github.com ("https://github.com/acme2")');
+
         $versionFrom = new Version('v1.0.0.0', 'v1.0.0', 'v1.0.0');
         $versionTo = new Version('v1.0.1.0', 'v1.0.1', 'v1.0.1');
 

--- a/tests/UrlGenerator/GitlabUrlGeneratorTest.php
+++ b/tests/UrlGenerator/GitlabUrlGeneratorTest.php
@@ -11,15 +11,16 @@
 
 namespace Pyrech\ComposerChangelogs\tests\UrlGenerator;
 
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\UrlGenerator\GitlabUrlGenerator;
 use Pyrech\ComposerChangelogs\Version;
 
-class GitlabUrlGeneratorTest extends \PHPUnit_Framework_TestCase
+class GitlabUrlGeneratorTest extends TestCase
 {
     /** @var GitlabUrlGenerator */
     private $SUT;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->SUT = new GitlabUrlGenerator('gitlab.company.org');
     }

--- a/tests/UrlGenerator/WordPressUrlGeneratorTest.php
+++ b/tests/UrlGenerator/WordPressUrlGeneratorTest.php
@@ -11,17 +11,18 @@
 
 namespace Pyrech\ComposerChangelogs\tests\UrlGenerator;
 
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\UrlGenerator\WordPressUrlGenerator;
 use Pyrech\ComposerChangelogs\Version;
 
-class WordPressUrlGeneratorTest extends \PHPUnit_Framework_TestCase
+class WordPressUrlGeneratorTest extends TestCase
 {
     /**
      * @var WordPressUrlGenerator
      */
     private $SUT;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->SUT = new WordPressUrlGenerator();
     }

--- a/tests/Util/FileSystemHelperTest.php
+++ b/tests/Util/FileSystemHelperTest.php
@@ -11,9 +11,10 @@
 
 namespace Pyrech\ComposerChangelogs\tests\Util;
 
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\Util\FileSystemHelper;
 
-class FileSystemHelperTest extends \PHPUnit_Framework_TestCase
+class FileSystemHelperTest extends TestCase
 {
     public function test_it_correctly_differentiates_absolute_paths_from_relative_ones()
     {

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -11,9 +11,10 @@
 
 namespace Pyrech\ComposerChangelogs\tests;
 
+use PHPUnit\Framework\TestCase;
 use Pyrech\ComposerChangelogs\Version;
 
-class VersionTest extends \PHPUnit_Framework_TestCase
+class VersionTest extends TestCase
 {
     /** @var Version */
     private $SUT;


### PR DESCRIPTION
Hey 👋 

I've updated the dependencies to their latest available versions.

Theres two main bumps here:
- PHPUnit 4.x -> 7.5
- php-cs-fixer 1.x -> 2.x

I've tried to port as much of the cs fixer config over but I noticed that it's reordered the comparison operators in some places. I hope this is ok but let me know if you'd like anything changed.