### PR TITLE
Default auto commit confirm to "true".

### DIFF
--- a/src/ChangelogsPlugin.php
+++ b/src/ChangelogsPlugin.php
@@ -133,7 +133,7 @@ class ChangelogsPlugin implements PluginInterface, EventSubscriberInterface
             case 'never':
                 return;
             case 'ask':
-                if ($this->io->askConfirmation('<info>Would you like to commit the update? </info>[<comment>no</comment>]: ', false)) {
+                if ($this->io->askConfirmation('<info>Would you like to commit the update? </info>[<comment>yes</comment>]: ', true)) {
                     $this->doCommit();
                 }
                 break;


### PR DESCRIPTION
I'd like to automate the `composer update` auto commits, but currently it skips committing when using the `--non-interactive` option.

I almost always want to commit when running interactively as well. 

For both of these reasons, I think it's nice to default the confirmation to commit to "yes".